### PR TITLE
Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+install: bash travis-setup.sh
+before_script:
+  - export PATH=$HOME/anaconda/bin:$PATH
+  - export JAVA_HOME=
+script: snakemake -prs rnaseq.snakefile --configfile test_config.yaml --use-conda -j1

--- a/common.py
+++ b/common.py
@@ -7,6 +7,15 @@ from lcdblib.snakemake import aligners, helpers
 from snakemake.shell import shell
 
 
+def gzipped(tmpfiles, outfile):
+    """
+    Cat-and-gzip input files into a single output file.
+    """
+    with gzip.open(outfile, 'wt') as fout:
+        for f in tmpfiles:
+            for line in open(f):
+                fout.write(line)
+
 def cat(tmpfiles, outfile):
     shell('cat {tmpfiles} > {outfile}')
 

--- a/get-data.py
+++ b/get-data.py
@@ -1,0 +1,17 @@
+import os
+from snakemake.shell import shell
+from snakemake.utils import makedirs
+
+URL = 'https://github.com/lcdb/lcdb-test-data/blob/master/data/{}?raw=true'
+
+def _download_file(fn, dest=None):
+    url = URL.format(fn)
+    if dest is None:
+        dest = fn
+    makedirs(os.path.dirname(dest))
+    basename = os.path.basename(fn)
+    shell('wget -q -O- {url} > {dest}')
+    return dest
+
+_download_file('samples/sample1/sample1_R1.fastq.gz')
+_download_file('samples/sample2/sample2_R1.fastq.gz')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 snakemake >=3.9
-multiqc
-biopython
-hisat2
-bowtie2
-picard
+lcdblib

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,0 +1,63 @@
+sampletable: 'sampletable.tsv'
+assembly: 'dm6'
+
+# If not specified here, use the environment variable REFERENCES_DIR.
+references_dir: references_data
+
+aligner:
+    index: 'hisat2'
+    tag: 'test'
+
+rrna:
+    index: 'bowtie2'
+    tag: 'rRNA'
+
+gtf:
+    tag: "test"
+
+kallisto:
+    tag: "test_transcriptome"
+
+
+# references has the structure:
+#
+#   assembly:           [ used as top-level dir for references ]
+#     tag:              [ user-defined; often indicates version or release ]
+#       type:           [ must be either "gtf" or "fasta" ]
+#         url:          [ string or list of urls ]
+#         postprocess:  [ string of importable function or dict of function and args ]
+#         conversions:  [ list of gtf conversions; only if type == gtf ]
+#         indexes:      [ list of indexes to build; only if type == fasta ]
+
+references:
+  dm6:
+    test:
+      gtf:
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/annotation/dm6.gtf"
+        postprocess: 'common.gzipped'
+        conversions:
+          - 'refflat'
+      fasta:
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/2L.fa"
+        postprocess: 'common.gzipped'
+        indexes:
+          - 'bowtie2'
+          - 'hisat2'
+
+    test_transcriptome:
+      fasta:
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/transcriptome.fa/"
+        indexes:
+          - 'kallisto'
+
+    rRNA:
+      fasta:
+        url:
+          - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_LSURef_tax_silva_trunc.fasta.gz'
+          - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_SSURef_Nr99_tax_silva_trunc.fasta.gz'
+        postprocess:
+            function: 'common.filter_fastas'
+            args: 'Drosophila melanogaster'
+        indexes:
+            - 'hisat2'
+            - 'bowtie2'

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+# Sets up travis-ci environment for testing bioconda-utils.
+curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/anaconda
+export PATH=$HOME/anaconda/bin:$PATH
+
+# Add channels in the specified order.
+conda config --add channels conda-forge
+conda config --add channels defaults
+conda config --add channels r
+conda config --add channels bioconda
+conda config --add channels lcdb
+
+conda install -y --file requirements.txt
+
+python get-data.py


### PR DESCRIPTION
Now that we have a decent framework for the wrapper tests, it was straightforward to add the tests here.

There's a `test_config.yaml` that gets the small fastqs, fasta, and gtf from lcdb test data.

This is currently failing because of HTTP 500 errors from the anaconda servers (which seems to happen periodically). The solution is to keep restarting the build.