### PR TITLE
bootstrap script

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 import argparse

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import argparse
+import tempfile
+from snakemake.shell import shell
+import glob
+
+usage = """
+Clones the repo into a new directory ready for a new analysis.
+
+Specifically:
+
+    - clone current repo to a temp dir
+    - check out a new branch in the tmp repo
+    - git rm everything that isn't listed on manifest.txt and commit on the new branch
+    - add the github repo as "upstream" remote
+    - copy the directory over, but warn about conflicts
+"""
+BLUE = '\033[94m'
+GREEN = '\033[92m'
+YELLOW = '\033[93m'
+RED = '\033[91m'
+END = '\033[0m'
+
+ap = argparse.ArgumentParser()
+ap.add_argument('dest', help='Target directory. Will be created if needed')
+ap.add_argument('--label', help='creates a new branch of this name.', required=True)
+ap.add_argument('--https', action='store_true',
+                help='''when setting the upstream remote, use https rather than
+                'ssh url''')
+args = ap.parse_args()
+
+source_dir = os.path.dirname(os.path.realpath(__file__))
+dest_dir = args.dest
+
+if not os.path.exists(dest_dir):
+    os.makedirs(dest_dir)
+else:
+    if os.path.exists(os.path.join(dest_dir, '.git')):
+        print(RED + "\nERROR: {dest_dir} appears to be an existing git repo, aborting.\n".format(**locals()) + END)
+        sys.exit(1)
+
+
+def recursive_find(paths):
+    files = []
+    for path in paths:
+        if not os.path.isdir(path):
+            files.append(path)
+            continue
+        for root, dirnames, filenames in os.walk(path):
+            for filename in filenames:
+                files.append(os.path.join(root, filename))
+    return files
+
+
+def _run(cmd):
+    print('\t' + YELLOW + cmd + END)
+    shell(cmd)
+
+tmpdir = tempfile.mkdtemp()
+_run(
+    'cd {tmpdir} '
+    '&& git clone {source_dir} . '
+    '&& git submodule init '
+    '&& git submodule update '
+    '&& git checkout -b {args.label}'.format(**locals()))
+
+
+
+
+# Whitelist of globs indicating files to keep
+MANIFEST = [i.strip() for i in open('manifest.txt') if
+            len(i.strip()) > 0 and not i.startswith('#')]
+
+keep = []
+for m in MANIFEST:
+    keep.extend(recursive_find(glob.glob(os.path.join(tmpdir, m))))
+
+# exhaustive list of files in the repo.
+existing_in_repo = recursive_find([tmpdir])
+
+# Anything not in the whitelist gets deleted from the temp repo
+to_remove = set(existing_in_repo).difference(set(keep))
+
+# If we have something existing in the dest (say, an existing config file),
+# then add that to the remove list so that when copying over we don't
+# overwrite.
+existing_in_dest = recursive_find([args.dest])
+to_remove = to_remove.union(existing_in_dest)
+
+# add the remote
+if not args.https:
+    remote = 'git@github.com:lcdb/lcdb-wf.git'
+else:
+    remote = 'https://github.com/lcdb/lcdb-wf.git'
+_run('cd {tmpdir} && git remote add upstream {remote}'.format(**locals()))
+
+
+# Now remove anything specified 
+for r in list(to_remove):
+    r = os.path.relpath(r, tmpdir)
+    _run('(cd {tmpdir} && git rm -r {r} --quiet)'.format(**locals()))
+
+_run('cd {tmpdir} && git commit -a -m "cleanup for new project \'{args.label}\' in {dest_dir}" --quiet'.format(**locals()))
+
+_run('rsync -r {tmpdir}/ {dest_dir}/'.format(**locals()))
+

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -87,7 +87,7 @@ to_remove = set(existing_in_repo).difference(set(keep))
 # then add that to the remove list so that when copying over we don't
 # overwrite.
 existing_in_dest = recursive_find([args.dest])
-to_remove = to_remove.union(existing_in_dest)
+to_remove = to_remove.union(set(existing_in_dest).intersection(existing_in_repo))
 
 # add the remote
 if not args.https:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -99,7 +99,6 @@ _run('cd {tmpdir} && git remote add upstream {remote}'.format(**locals()))
 
 # Now remove anything specified 
 for r in list(to_remove):
-    r = os.path.relpath(r, tmpdir)
     _run('(cd {tmpdir} && git rm -r {r} --quiet)'.format(**locals()))
 
 _run('cd {tmpdir} && git commit -a -m "cleanup for new project \'{args.label}\' in {dest_dir}" --quiet'.format(**locals()))

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -70,8 +70,8 @@ _run(
 
 
 # Whitelist of globs indicating files to keep
-MANIFEST = [i.strip() for i in open('manifest.txt') if
-            len(i.strip()) > 0 and not i.startswith('#')]
+MANIFEST = [i.strip() for i in open(os.path.join(source_dir, 'manifest.txt'))
+            if len(i.strip()) > 0 and not i.startswith('#')]
 
 keep = []
 for m in MANIFEST:

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,29 @@
+# whitelist of files that should be copied over
+
+README.md
+
+# should have better organization; adapters.fa doesn't need to be in top level
+adapters.fa
+
+# definitely need snakefiles
+references.snakefile
+rnaseq.snakefile
+
+common.py
+
+envs/*
+postprocess/*
+
+# we want to keep everything in wrappers because otherwise dealing with the
+# submodule gets annoying
+wrappers/*
+wrappers/.*
+
+# git internals
+.gitignore
+.gitmodules
+.git
+
+requirements.txt
+test_config.yaml
+config.yml


### PR DESCRIPTION
This provides a way of cloning the repo into a new analysis directory.

The idea is that there's a whitelist (`manifest.txt`) of files in the repo that should be copied, anything not on the list is skipped.

```bash
git clone . tmpdir
cd tmpdir
git remote add upstream git@github.com:lcdb/lcdb-wf.git
git checkout -b newbranch
git rm $files-to-remove  # see below
git commit -m 'deleted stuff'
rsync tmpdir/ destdir/
```
Which files to delete from the temporary cloned repo: anything NOT matched by globs in `manifest.txt`, and  anything  that already exists in the destination dir.