### PR TITLE
render rnaseq report

### DIFF
--- a/ci/get-data.py
+++ b/ci/get-data.py
@@ -17,9 +17,11 @@ def _download_file(fn, dest=None):
 
 _download_file('rnaseq_samples/sample1/sample1.small_R1.fastq.gz')
 _download_file('rnaseq_samples/sample2/sample2.small_R1.fastq.gz')
+_download_file('rnaseq_samples/sample3/sample3.small_R1.fastq.gz')
+_download_file('rnaseq_samples/sample4/sample4.small_R1.fastq.gz')
 
-shell('mkdir -p data/rnaseq_samples/sample{{1,2}}')
-for n in [1, 2]:
+shell('mkdir -p data/rnaseq_samples/sample{{1,2,3,4}}')
+for n in [1, 2, 3, 4]:
     shell(
         'mv rnaseq_samples/sample{n}/sample{n}.small_R1.fastq.gz '
         'data/rnaseq_samples/sample{n}/sample{n}_R1.fastq.gz'

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -1,0 +1,16 @@
+channels:
+  - bioconda
+  - conda-forge
+  - r
+
+dependencies:
+  - bioconductor-org.hs.eg.db
+  - bioconductor-org.dm.eg.db
+  - bioconductor-org.mm.eg.db
+  - bioconductor-deseq2
+  - r-rmarkdown
+  - pandoc
+  - r-knitrbootstrap
+  - r-knitr
+  - r-pheatmap
+

--- a/config/sampletable.tsv
+++ b/config/sampletable.tsv
@@ -1,3 +1,5 @@
-samplename	treatment
+samplename	group
 sample1	control
 sample2	control
+sample3	treatment
+sample4	treatment

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -16,12 +16,12 @@ library(pheatmap)
 library(RColorBrewer)
 library(ggplot2)
 library(genefilter)
-library(org.Hs.eg.db)
-sample.table.filename = '../sampletable.tsv'
+library(org.Dm.eg.db)
+sample.table.filename = '../config/sampletable.tsv'
 colData <- read.table(sample.table.filename, sep='\t', header=TRUE)
 colData$path <- sapply(
     colData$samplename,
-    function (x) file.path('samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
+    function (x) file.path('data', 'rnaseq_samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
                            )
     )
 
@@ -238,7 +238,7 @@ res.list <- list(group=res)
 for (name in names(res.list)){
     res <- res.list[[name]]
     res$symbol <- mapIds(
-        org.Hs.eg.db,
+        org.Dm.eg.db,
         keys=row.names(res),
         column="SYMBOL",
         keytype="ENSEMBL",

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -74,6 +74,9 @@ patterns = {
     'rseqc': {
         'bam_stat': '{sample_dir}/{sample}/rseqc/{sample}_bam_stat.txt',
     },
+    'downstream': {
+        'rnaseq': 'downstream/rnaseq.html',
+    }
 }
 fill = dict(sample=samples, sample_dir=sample_dir, agg_dir=agg_dir)
 targets = helpers.fill_patterns(patterns, fill)
@@ -96,7 +99,8 @@ rule targets:
             utils.flatten(targets['dupradar']) +
             utils.flatten(targets['salmon']) +
             utils.flatten(targets['rseqc']) +
-            utils.flatten(targets['collectrnaseqmetrics'])
+            utils.flatten(targets['collectrnaseqmetrics']) +
+            utils.flatten(targets['downstream'])
         )
 
 
@@ -310,5 +314,19 @@ rule rseqc_bam_stat:
     output:
         txt=patterns['rseqc']['bam_stat']
     wrapper: wrapper_for('rseqc/bam_stat')
+
+
+rule rnaseq_rmarkdown:
+    input:
+        featurecounts=targets['featurecounts'],
+        rmd='downstream/rnaseq.Rmd',
+        sampletable=config['sampletable']
+    output:
+        'downstream/rnaseq.html'
+    conda:
+        'config/envs/R_rnaseq.yaml'
+    shell:
+        'Rscript -e '
+        '''"rmarkdown::render('{input.rmd}', 'knitrBootstrap::bootstrap_document')"'''
 
 # vim: ft=python


### PR DESCRIPTION
This adds a rule and necessary infrastructure for rendering a default rnaseq DE analysis based on the sampletable. Doing so required adding the other two samples from the example data.

I'd like to eventually add config options to the Rmd to choose the correct annotation db; currently you have to switch to e.g., `org.Hs.eg.db` manually. The `rnaseq.Rmd` is intended to be heavily edited anyway based on the particular experiment, so I'm not to worried about that.