### PR TITLE
tximport, salmon, sva

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - setup.log
   -
     label: wrappers
-    command: source $HOME/anaconda/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
+    command: source /tmp/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
   -
     label: rnaseq
-    command: source $HOME/anaconda/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6
+    command: source /tmp/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - setup.log
   -
     label: wrappers
-    command: source /tmp/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
+    command: source /tmp/ci/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
   -
     label: rnaseq
-    command: source /tmp/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6
+    command: source /tmp/ci/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__
 data
 references_data
+downstream/group.tsv
+downstream/rnaseq.html
+downstream/rnaseq_cache
+downstream/rnaseq_files

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 install: bash ci/travis-setup.sh
 before_script:
-  - export PATH=$HOME/anaconda/bin:$PATH
+  - export PATH=/tmp/ci/ana/bin:$PATH
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 set -x
 
-CONDA_DIR=$HOME/anaconda
+CONDA_DIR=/tmp/ci/ana
 ENVNAME=lcdb-wf-test
 
 # buildkite expects this as a build artifact; make sure it exists even if other
@@ -42,4 +42,3 @@ conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
 
 source activate $ENVNAME
 python ci/get-data.py
-

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -8,10 +8,12 @@ dependencies:
   - bioconductor-org.hs.eg.db
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
+  - bioconductor-genomicfeatures
   - bioconductor-tximport
   - r-rmarkdown
   - pandoc
   - r-knitrbootstrap
   - r-knitr
   - r-pheatmap
-
+  - r-readr
+  - r-dt

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -4,10 +4,11 @@ channels:
   - r
 
 dependencies:
+  - bioconductor-deseq2
   - bioconductor-org.hs.eg.db
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
-  - bioconductor-deseq2
+  - bioconductor-tximport
   - r-rmarkdown
   - pandoc
   - r-knitrbootstrap

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -9,6 +9,7 @@ dependencies:
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
   - bioconductor-genomicfeatures
+  - bioconductor-sva
   - bioconductor-tximport
   - r-rmarkdown
   - pandoc

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -259,6 +259,32 @@ pval.hist(res)
 # pval.hist(res.interaction)
 ```
 
+```{r sva, cache=TRUE}
+# example of using SVA to find one surrogate variable
+library(sva)
+ddssva <- DESeqDataSetFromFeatureCounts(
+                                  sampleTable=colData,
+                                  directory='.',
+                                  design=~group)
+ddssva <- DESeq(ddssva)
+dat <- counts(ddssva, normalized=TRUE)
+idx <- rowMeans(dat) > 1
+dat <- dat[idx,]
+mod <- model.matrix(~group, colData(ddssva))
+mod0 <- model.matrix(~1, colData(ddssva))
+svseq <- svaseq(dat, mod, mod0, n.sv=1)
+ddssva$SV1 <- svseq$sv
+design(ddssva) <- ~SV1 + group
+ddssva <- DESeq(ddssva)
+
+df <- data.frame(colData(ddssva))
+df$samplename <- rownames(df)
+df$sv <- svseq$sv
+ggplot(df) + aes(x=samplename, y=sv, color=group) +
+    geom_point(size=5)
+```
+
+
 # Exported results
 
 See the [Help on results tables](#resultshelp) section for more information about these tables.

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -17,15 +17,22 @@ library(RColorBrewer)
 library(ggplot2)
 library(genefilter)
 library(org.Dm.eg.db)
+library(readr)
+library(tximport)
 sample.table.filename = '../config/sampletable.tsv'
 colData <- read.table(sample.table.filename, sep='\t', header=TRUE)
-colData$path <- sapply(
+colData$featurecounts.path <- sapply(
     colData$samplename,
-    function (x) file.path('data', 'rnaseq_samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
+    function (x) file.path('..', 'data', 'rnaseq_samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
                            )
     )
 
-colData <- colData[, c('samplename', 'path', 'group')]
+colData$salmon.path <- sapply(
+    colData$samplename,
+    function (x) file.path('..', 'data', 'rnaseq_samples', x, paste0(x, '.salmon'), 'quant.sf')
+)
+
+colData <- colData[, c('samplename', 'featurecounts.path', 'salmon.path', 'group')]
 colData$group <- factor(colData$group)
 knitr::kable(colData[, !grepl('path', colnames(colData))])
 ```
@@ -37,7 +44,7 @@ DESeqDataSetFromFeatureCounts <- function (sampleTable, directory='.', design,
                                            ignoreRank=FALSE,  ...)
 {
   l <- lapply(
-    as.character(sampleTable[, 'path']),
+    as.character(sampleTable[, 'featurecounts.path']),
     function(fn) read.table(file.path(directory, fn), stringsAsFactors=FALSE, skip=2)
   )
   if (!all(sapply(l, function(a) all(a$V1 == l[[1]]$V1))))
@@ -52,10 +59,33 @@ DESeqDataSetFromFeatureCounts <- function (sampleTable, directory='.', design,
 }
 ```
 
+```{r}
+DESeqDataSetFromSalmon <- function (sampleTable, directory='.', design,
+                                           ignoreRank=FALSE,  ...)
+{
+    txi <- tximport(sampleTable[, 'salmon.path'], type='salmon', reader=read_tsv, txOut=TRUE)
+    object <- DESeqDataSetFromTximport(txi, colData=sampleTable[, -grepl('path', colnames(sampleTable)),
+                                       drop=FALSE], design=design, ignoreRank, ...)
+    return(object)
+}
+```
+
+```{r ddstxi, cache=TRUE}
+dds.txi <- DESeqDataSetFromSalmon(
+                                  sampleTable=colData,
+                                  directory='.',
+                                  design=~group)
+```
+
+```{r rldtxi, cache=TRUE, depends='ddstxi'}
+rld.txi <- rlog(dds.txi, blind=FALSE)
+```
+
+
 ```{r dds, cache=TRUE}
 dds <- DESeqDataSetFromFeatureCounts(
                                   sampleTable=colData,
-                                  directory='..',
+                                  directory='.',
                                   design=~group)
 ```
 


### PR DESCRIPTION
This PR adds further improvements to rnaseq.Rmd.

- adds the import of salmon transcript-level counts into a DESeq object using the tximport package
- adds an example of using SVA and how to plot it vs other metadata to help with interpretation
- makes some fixes to the testing setup (use a shorter path to avoid conda complaining about 80-char limits; was hitting this for some R packages)
