### PR TITLE
R annotation stuff

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - setup.log
   -
     label: wrappers
-    command: source $HOME/anaconda/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
+    command: source /tmp/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
   -
     label: rnaseq
-    command: source $HOME/anaconda/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6
+    command: source /tmp/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,9 +4,13 @@ steps:
     command: bash ci/travis-setup.sh
     artifact_paths:
       - setup.log
+
   -
     label: wrappers
     command: source /tmp/ci/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
+
   -
-    label: rnaseq
-    command: source /tmp/ci/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6
+    label: workflows
+    command: 
+      - source /tmp/ci/ana/bin/activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j6
+      - source /tmp/ci/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - setup.log
   -
     label: wrappers
-    command: source /tmp/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
+    command: source /tmp/ci/ana/bin/activate lcdb-wf-test && pytest wrappers/test -v -n6
   -
     label: rnaseq
-    command: source /tmp/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6
+    command: source /tmp/ci/ana/bin/activate lcdb-wf-test && python ci/get-data.py && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j6

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__
 data
 references_data
+downstream/group.tsv
+downstream/rnaseq.html
+downstream/rnaseq_cache
+downstream/rnaseq_files

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ downstream/group.tsv
 downstream/rnaseq.html
 downstream/rnaseq_cache
 downstream/rnaseq_files
+
+\.cache/v/cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 install: bash ci/travis-setup.sh
 before_script:
-  - export PATH=$HOME/anaconda/bin:$PATH
+  - export PATH=/tmp/ci/ana/bin:$PATH
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ before_script:
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:
+  - source activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j1
   - source activate lcdb-wf-test && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j1
   - source activate lcdb-wf-test && py.test wrappers/test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_script:
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:
-  - source activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j1
-  - source activate lcdb-wf-test && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j1
-  - source activate lcdb-wf-test && py.test wrappers/test -v
+  - source activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j2
+  - source activate lcdb-wf-test && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j2
+  - source activate lcdb-wf-test && py.test wrappers/test -n2 -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,4 @@ before_script:
   - export PATH=/tmp/ci/ana/bin:$PATH
   - export JAVA_HOME=
   - export TMPDIR=/tmp
-script:
-  - source activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j2
-  - source activate lcdb-wf-test && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j2
-  - source activate lcdb-wf-test && py.test wrappers/test -n2 -v
+script: ci/travis-run.sh

--- a/ci/travis-run.sh
+++ b/ci/travis-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ $TRAVIS_BRANCH != "master" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_REPO_SLUG == "lcdb/lcdb-wf" ]]
+then
+    echo ""
+    echo "Tests are skipped for non-master-branch pushes to the main repo."
+    echo "If you have opened a pull request, please see the full tests for that PR."
+    echo ""
+    exit 0
+fi
+
+source activate lcdb-wf-test && snakemake -prs references.snakefile --configfile config/test_config.yaml --use-conda -j2
+source activate lcdb-wf-test && snakemake -prs rnaseq.snakefile --configfile config/test_config.yaml --use-conda -j2
+source activate lcdb-wf-test && py.test wrappers/test -n2 -v

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -2,12 +2,17 @@
 set -eo pipefail
 set -x
 
+if [[ $TRAVIS_BRANCH != "master" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_REPO_SLUG == "lcdb/lcdb-wf" ]]
+then
+    echo ""
+    echo "Tests are skipped for non-master-branch pushes to the main repo."
+    echo "If you have opened a pull request, please see the full tests for that PR."
+    echo ""
+    exit 0
+fi
+
 CONDA_DIR=/tmp/ci/ana
 ENVNAME=lcdb-wf-test
-
-# buildkite expects this as a build artifact; make sure it exists even if other
-# commands fail
-touch setup.log
 
 curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
@@ -21,23 +26,8 @@ conda config --add channels r
 conda config --add channels bioconda
 conda config --add channels lcdb
 
-# Environment exists; update with requirements. This can happen on a buildkite
-# agent.
-if conda env list | grep -q $ENVNAME; then
-
-    # echo "Environment $ENVNAME exists; updating it"
-    # conda install -y --file requirements.txt python=3.5
-
-    # Remove the env. Seems like we're getting strange mkl symlink errors
-    conda env remove -y -n $ENVNAME
-fi
-
-# Otherwise create a new environment (this will happen every time on
-# travis-ci). Don't show the progress for package downloads in the main
-# log, but provide setup.log as a build artifact for buildkite.
 echo "Building environment $ENVNAME"
 conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
-    | tee setup.log \
     | grep -v " Time: "
 
 source activate $ENVNAME

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 set -x
 
-CONDA_DIR=$HOME/anaconda
+CONDA_DIR=/tmp/ci/ana
 ENVNAME=lcdb-wf-test
 
 # buildkite expects this as a build artifact; make sure it exists even if other
@@ -42,4 +42,3 @@ conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
 
 source activate $ENVNAME
 python ci/get-data.py
-

--- a/config/config.yml
+++ b/config/config.yml
@@ -25,7 +25,7 @@ kallisto:
 #     tag:              [ user-defined; often indicates version or release ]
 #       type:           [ must be either "gtf" or "fasta" ]
 #         url:          [ string or list of urls ]
-#         lib.postprocess:  [ string of importable function or dict of function and args ]
+#         postprocess:  [ string of importable function or dict of function and args ]
 #         conversions:  [ list of gtf conversions; only if type == gtf ]
 #         indexes:      [ list of indexes to build; only if type == fasta ]
 
@@ -35,7 +35,7 @@ references:
     default:
       fasta:
         url: 'http://hgdownload.cse.ucsc.edu/goldenPath/sacCer3/bigZips/chromFa.tar.gz'
-        lib.postprocess: 'lib.postprocess.sacCer3.fasta_lib.postprocess'
+        postprocess: 'lib.postprocess.sacCer3.fasta_lib.postprocess'
         indexes:
             - 'bowtie2'
 
@@ -44,14 +44,14 @@ references:
 
       gtf:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/gtf/dmel-all-r6.11.gtf.gz'
-        lib.postprocess: "lib.postprocess.dm6.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.gtf_lib.postprocess"
         conversions:
           - 'refflat'
           - 'gffutils'
 
       fasta:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-chromosome-r6.11.fasta.gz'
-        lib.postprocess: "lib.postprocess.dm6.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.fasta_lib.postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
@@ -67,7 +67,7 @@ references:
         url:
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_LSURef_tax_silva_trunc.fasta.gz'
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_SSURef_Nr99_tax_silva_trunc.fasta.gz'
-        lib.postprocess:
+        postprocess:
             function: 'lib.common.filter_fastas'
             args: 'Drosophila melanogaster'
         indexes:
@@ -83,7 +83,7 @@ references:
           - 'bowtie2'
       gtf:
         url: 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_25/gencode.v25.annotation.gtf.gz'
-        lib.postprocess: 'lib.postprocess.hg38.strip_ensembl_version'
+        postprocess: 'lib.postprocess.hg38.strip_ensembl_version'
 
     gencode-v25-transcriptome:
       fasta:
@@ -99,14 +99,14 @@ references:
           - 'hisat2'
       gtf:
         url: 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.annotation.gtf.gz'
-        lib.postprocess: 'lib.postprocess.hg38.strip_ensembl_version'
+        postprocess: 'lib.postprocess.hg38.strip_ensembl_version'
 
     gencode_v19_plus_lncRNA_transcriptome:
       fasta:
         url:
           - 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.pc_transcripts.fa.gz'
           - 'ftp://ftp.sanger.ac.uk/pub/gencode/Gencode_human/release_19/gencode.v19.lncRNA_transcripts.fa.gz'
-        lib.postprocess: "lib.common.cat"
+        postprocess: "lib.common.cat"
         indexes:
           - 'kallisto'
 
@@ -115,7 +115,7 @@ references:
         url:
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_LSURef_tax_silva_trunc.fasta.gz'
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_SSURef_Nr99_tax_silva_trunc.fasta.gz'
-        lib.postprocess:
+        postprocess:
             function: 'lib.common.filter_fastas'
             args: 'Homo sapiens'
         indexes:
@@ -166,7 +166,7 @@ references:
         url:
             - "ftp://ftp.ensemblgenomes.org/pub/protists/release-33/fasta/dictyostelium_discoideum/cdna/Dictyostelium_discoideum.dicty_2.7.cdna.all.fa.gz"
             - "ftp://ftp.ensemblgenomes.org/pub/protists/release-33/fasta/dictyostelium_discoideum/ncrna/Dictyostelium_discoideum.dicty_2.7.ncrna.fa.gz"
-        lib.postprocess: "lib.common.cat"
+        postprocess: "lib.common.cat"
         indexes:
             - "kallisto"
 
@@ -184,7 +184,7 @@ references:
         indexes:
             - 'hisat2'
             - 'bowtie2'
-        lib.postprocess:
+        postprocess:
             function: 'lib.common.filter_fastas'
             args: 'Dictyostelium discoideum'
 
@@ -192,7 +192,7 @@ references:
     default:
       fasta:
         url: 'ftp://igenome:G3nom3s4u@ussd-ftp.illumina.com/PhiX/Illumina/RTA/PhiX_Illumina_RTA.tar.gz'
-        lib.postprocess: "lib.postprocess.phix.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.phix.fasta_lib.postprocess"
         indexes:
           - 'bowtie2'
 
@@ -200,29 +200,29 @@ references:
     srm2374:
       fasta:
         url: 'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
-        lib.postprocess: "lib.postprocess.ercc.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.ercc.fasta_lib.postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
       gtf:
         url: 'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
-        lib.postprocess: "lib.postprocess.ercc.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.ercc.gtf_lib.postprocess"
 
     fisher92:
       fasta:
         url: 'https://tools.thermofisher.com/content/sfs/manuals/ERCC92.zip'
-        lib.postprocess: "lib.postprocess.erccFisher.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.erccFisher.fasta_lib.postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
       gtf:
         url: 'https://tools.thermofisher.com/content/sfs/manuals/ERCC92.zip'
-        lib.postprocess: "lib.postprocess.erccFisher.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.erccFisher.gtf_lib.postprocess"
 
   adapters:
     default:
       fasta:
         url: 'https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/adapters.fa'
-        lib.postprocess: "lib.postprocess.adapters.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.adapters.fasta_lib.postprocess"
         indexes:
           - 'bowtie2'

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -8,10 +8,12 @@ dependencies:
   - bioconductor-org.hs.eg.db
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
+  - bioconductor-genomicfeatures
   - bioconductor-tximport
   - r-rmarkdown
   - pandoc
   - r-knitrbootstrap
   - r-knitr
   - r-pheatmap
-
+  - r-readr
+  - r-dt

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -4,10 +4,11 @@ channels:
   - r
 
 dependencies:
+  - bioconductor-deseq2
   - bioconductor-org.hs.eg.db
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
-  - bioconductor-deseq2
+  - bioconductor-tximport
   - r-rmarkdown
   - pandoc
   - r-knitrbootstrap

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -9,6 +9,7 @@ dependencies:
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db
   - bioconductor-genomicfeatures
+  - bioconductor-sva
   - bioconductor-tximport
   - r-rmarkdown
   - pandoc

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - bioconductor-deseq2
+  - bioconductor-annotationhub
   - bioconductor-org.hs.eg.db
   - bioconductor-org.dm.eg.db
   - bioconductor-org.mm.eg.db

--- a/config/envs/annotationdbi.yaml
+++ b/config/envs/annotationdbi.yaml
@@ -1,0 +1,7 @@
+channels:
+  - bioconda
+  - conda-forge
+  - r
+
+dependencies:
+  - bioconductor-annotationhub

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -67,6 +67,11 @@ references:
           - genelist:
               gene_id: 'gene_id'
 
+          - annotation_hub:
+              ahkey: 'AH49581'
+              keytype: 'ENSEMBL'
+
+
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
         postprocess: 'lib.common.gzipped'

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -20,21 +20,21 @@ assembly: 'dmel'
 references_dir: references_data
 
 aligner:
-    index: 'hisat2'
-    tag: 'test'
+  index: 'hisat2'
+  tag: 'test'
 
 rrna:
-    index: 'bowtie2'
-    tag: 'rRNA'
+  index: 'bowtie2'
+  tag: 'rRNA'
 
 gtf:
-    tag: "test"
+  tag: "test"
 
 kallisto:
-    tag: "test_transcriptome"
+  tag: "test_transcriptome"
 
 salmon:
-    tag: "test_transcriptome"
+  tag: "test_transcriptome"
 
 # references has the structure:
 #
@@ -54,6 +54,15 @@ references:
         postprocess: 'lib.common.gzipped'
         conversions:
           - 'refflat'
+          - gffutils: # kwargs below will be provided to `gffutils.create_db`
+              merge_strategy: 'merge'
+              id_spec:
+                  transcript: ['transcript_id', 'transcript_symbol']
+                  gene: ['gene_id', 'gene_symbol']
+              gtf_transcript_key: 'transcript_id'
+              gtf_gene_key: 'gene_id'
+              disable_infer_genes: True
+
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
         postprocess: 'lib.common.gzipped'
@@ -75,11 +84,11 @@ references:
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_LSURef_tax_silva_trunc.fasta.gz'
           - 'https://www.arb-silva.de/fileadmin/silva_databases/release_128/Exports/SILVA_128_SSURef_Nr99_tax_silva_trunc.fasta.gz'
         postprocess:
-            function: 'lib.common.filter_fastas'
-            args: 'Drosophila melanogaster'
+          function: 'lib.common.filter_fastas'
+          args: 'Drosophila melanogaster'
         indexes:
-            - 'hisat2'
-            - 'bowtie2'
+          - 'hisat2'
+          - 'bowtie2'
   phix:
     default:
       fasta:

--- a/config/test_config.yaml
+++ b/config/test_config.yaml
@@ -63,6 +63,10 @@ references:
               gtf_gene_key: 'gene_id'
               disable_infer_genes: True
 
+          # the attribute from the GTF to consider gene ID
+          - genelist:
+              gene_id: 'gene_id'
+
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
         postprocess: 'lib.common.gzipped'

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -10,6 +10,7 @@ Note: if you're unfamiliar with any of the plots or tables here, see the
 
 
 ```{r setup}
+options(bitmapType='cairo')
 library(DESeq2)
 library(gridExtra)
 library(pheatmap)

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -259,6 +259,32 @@ pval.hist(res)
 # pval.hist(res.interaction)
 ```
 
+```{r sva, cache=TRUE}
+# example of using SVA to find one surrogate variable
+library(sva)
+ddssva <- DESeqDataSetFromFeatureCounts(
+                                  sampleTable=colData,
+                                  directory='.',
+                                  design=~group)
+ddssva <- DESeq(ddssva)
+dat <- counts(ddssva, normalized=TRUE)
+idx <- rowMeans(dat) > 1
+dat <- dat[idx,]
+mod <- model.matrix(~group, colData(ddssva))
+mod0 <- model.matrix(~1, colData(ddssva))
+svseq <- svaseq(dat, mod, mod0, n.sv=1)
+ddssva$SV1 <- svseq$sv
+design(ddssva) <- ~SV1 + group
+ddssva <- DESeq(ddssva)
+
+df <- data.frame(colData(ddssva))
+df$samplename <- rownames(df)
+df$sv <- svseq$sv
+ggplot(df) + aes(x=samplename, y=sv, color=group) +
+    geom_point(size=5)
+```
+
+
 # Exported results
 
 See the [Help on results tables](#resultshelp) section for more information about these tables.

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -1,5 +1,5 @@
 ```{r, include=FALSE}
-knitr::opts_chunk$set(collapse=TRUE, warning=FALSE, message=FALSE, bootstrap.show.code=FALSE, bootstrap.show.output=FALSE)
+knitr::opts_chunk$set(collapse=TRUE, warning=FALSE, message=FALSE, bootstrap.show.code=FALSE, bootstrap.show.output=FALSE, dev='bitmap', fig.ext='png')
 ```
 # Differential expression 
 

--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -17,15 +17,22 @@ library(RColorBrewer)
 library(ggplot2)
 library(genefilter)
 library(org.Dm.eg.db)
+library(readr)
+library(tximport)
 sample.table.filename = '../config/sampletable.tsv'
 colData <- read.table(sample.table.filename, sep='\t', header=TRUE)
-colData$path <- sapply(
+colData$featurecounts.path <- sapply(
     colData$samplename,
-    function (x) file.path('data', 'rnaseq_samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
+    function (x) file.path('..', 'data', 'rnaseq_samples', x, paste0(x, '.cutadapt.bam.featurecounts.txt')
                            )
     )
 
-colData <- colData[, c('samplename', 'path', 'group')]
+colData$salmon.path <- sapply(
+    colData$samplename,
+    function (x) file.path('..', 'data', 'rnaseq_samples', x, paste0(x, '.salmon'), 'quant.sf')
+)
+
+colData <- colData[, c('samplename', 'featurecounts.path', 'salmon.path', 'group')]
 colData$group <- factor(colData$group)
 knitr::kable(colData[, !grepl('path', colnames(colData))])
 ```
@@ -37,7 +44,7 @@ DESeqDataSetFromFeatureCounts <- function (sampleTable, directory='.', design,
                                            ignoreRank=FALSE,  ...)
 {
   l <- lapply(
-    as.character(sampleTable[, 'path']),
+    as.character(sampleTable[, 'featurecounts.path']),
     function(fn) read.table(file.path(directory, fn), stringsAsFactors=FALSE, skip=2)
   )
   if (!all(sapply(l, function(a) all(a$V1 == l[[1]]$V1))))
@@ -52,10 +59,33 @@ DESeqDataSetFromFeatureCounts <- function (sampleTable, directory='.', design,
 }
 ```
 
+```{r}
+DESeqDataSetFromSalmon <- function (sampleTable, directory='.', design,
+                                           ignoreRank=FALSE,  ...)
+{
+    txi <- tximport(sampleTable[, 'salmon.path'], type='salmon', reader=read_tsv, txOut=TRUE)
+    object <- DESeqDataSetFromTximport(txi, colData=sampleTable[, -grepl('path', colnames(sampleTable)),
+                                       drop=FALSE], design=design, ignoreRank, ...)
+    return(object)
+}
+```
+
+```{r ddstxi, cache=TRUE}
+dds.txi <- DESeqDataSetFromSalmon(
+                                  sampleTable=colData,
+                                  directory='.',
+                                  design=~group)
+```
+
+```{r rldtxi, cache=TRUE, depends='ddstxi'}
+rld.txi <- rlog(dds.txi, blind=FALSE)
+```
+
+
 ```{r dds, cache=TRUE}
 dds <- DESeqDataSetFromFeatureCounts(
                                   sampleTable=colData,
-                                  directory='..',
+                                  directory='.',
                                   design=~group)
 ```
 

--- a/references.snakefile
+++ b/references.snakefile
@@ -117,4 +117,16 @@ rule chromsizes:
         '| sed "s/SN://g;s/ LN:/\\t/g" > {output} '
         '&& rm -f {output}.tmp '
 
+
+rule genelist:
+    input: gtf='{references_dir}/{assembly}/{tag}/gtf/{assembly}_{tag}.gtf'
+    output:
+        protected('{references_dir}/{assembly}/{tag}/gtf/{assembly}_{tag}.genelist')
+    run:
+        attribute = conversion_kwargs[output[0]]['gene_id']
+        import gffutils
+        with open(output[0], 'w') as fout:
+            for feature in gffutils.DataIterator(input.gtf):
+                fout.write(feature.attributes[attribute][0] + '\n')
+
 # vim: ft=python

--- a/references.snakefile
+++ b/references.snakefile
@@ -138,7 +138,7 @@ rule annotations:
         prefix='{references_dir}/{assembly}/{tag}/gtf/{assembly}_{tag}',
         ahkey=lambda wildcards, output: conversion_kwargs[output[0]]['ahkey']
 
-    conda: 'config/envs/R_rnaseq.yaml'
+    conda: 'config/envs/annotationdbi.yaml'
     shell:
         '''Rscript -e "'''
         "library(AnnotationHub); "
@@ -146,8 +146,8 @@ rule annotations:
         "db <- ah[['{params.ahkey}']]; "
         "gene.names <- read.table('{input}', stringsAsFactors=FALSE)[['V1']];"
         "for (col in columns(db)){{"
-        "    f <- select(db, keys=gene.names, keytype='{wildcards.keytype}', columns=col);"
-        "    write.csv(f, file=paste0('{params.prefix}', '.', col, '.csv'), row.names=FALSE);"
+        "f <- select(db, keys=gene.names, keytype='{wildcards.keytype}', columns=col);"
+        "write.csv(f, file=paste0('{params.prefix}', '.', col, '.csv'), row.names=FALSE);"
         '''}}"'''
 
 

--- a/references.snakefile
+++ b/references.snakefile
@@ -20,9 +20,10 @@ def wrapper_for(path):
 references_dir = get_references_dir(config)
 makedirs([references_dir, os.path.join(references_dir, 'logs')])
 
+refdict, conversion_kwargs = references_dict(config)
 
 rule all_references:
-    input: utils.flatten(references_dict(config))
+    input: utils.flatten(refdict)
 
 
 # Downloads the configured URL, applies any configured post-processing, and
@@ -99,12 +100,8 @@ rule conversion_gffutils:
     log: '{references_dir}/logs/{assembly}/{tag}/gtf/{assembly}_{tag}.gtf.db.log'
     run:
         import gffutils
-        db = gffutils.create_db(
-                data=input.gtf, dbfn=output.db, merge_strategy='merge',
-                id_spec={'transcript': ['transcript_id', 'transcript_symbol'],
-                         'gene': ['gene_id', 'gene_symbol']},
-                gtf_transcript_key='transcript_id', gtf_gene_key='gene_id',
-                disable_infer_genes=True)
+        kwargs = conversion_kwargs[output[0]]
+        db = gffutils.create_db(data=input.gtf, dbfn=output.db, **kwargs)
 
 
 rule chromsizes:

--- a/references.snakefile
+++ b/references.snakefile
@@ -125,9 +125,12 @@ rule genelist:
     run:
         attribute = conversion_kwargs[output[0]]['gene_id']
         import gffutils
+        genes = set()
+        for feature in gffutils.DataIterator(input.gtf):
+            genes.update(feature.attributes[attribute])
         with open(output[0], 'w') as fout:
-            for feature in gffutils.DataIterator(input.gtf):
-                fout.write(feature.attributes[attribute][0] + '\n')
+            for feature in sorted(list(set(genes))):
+                fout.write(feature + '\n')
 
 
 rule annotations:


### PR DESCRIPTION
This PR provides a general mechanism for getting CSVs of `gene_id` to any number of other accessions or metadata. 

This required some other changes, which I'm rolling into one big PR again. Specifically:

- we now get annotation lookup tables in the references dir (see below)
- arbitrary kwargs can now be supplied in the config YAML and are passed to conversion functions. The gffutils rule, genelist rule, and annotations rule now use this mechanism. See the updated config.yaml below for what it looks like.
- added ability to import salmon transcript-level counts into DESeq2
- the RMarkdown is now rendered; this needed some tweaking to the device in order for the tests to run headless
- lots of playing around with buildkite. After much deliberation I've decided it's not worth the additional complexity and cost. I've disabled the buildkite side of things, but kept the configs in here for possible future use.


The relevant section of the `config.yaml` now reads:

```yaml
dmel:
  test:
    gtf:
        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/annotation/dm6.small.gtf"
        postprocess: 'lib.common.gzipped'

        conversions:
          - 'refflat'
          - gffutils: # kwargs below will be provided to `gffutils.create_db`
              merge_strategy: 'merge'
              id_spec:
                  transcript: ['transcript_id', 'transcript_symbol']
                  gene: ['gene_id', 'gene_symbol']
              gtf_transcript_key: 'transcript_id'
              gtf_gene_key: 'gene_id'
              disable_infer_genes: True

          # the attribute from the GTF to consider gene ID
          - genelist:
              gene_id: 'gene_id'

          - annotation_hub:
              ahkey: 'AH49581'
              keytype: 'ENSEMBL'
```

For the test data, where we're using drosophila, we use the AnnotationHub accession `AH49581` and get the following files in `references_data/dmel/test/gtf`:

```bash
# gtf, refflat, and gffutils db stuff that we've already had
dmel_test.gtf
dmel_test.gtf.db
dmel_test.gtf.gz.log
dmel_test.refflat

# 1-column list of genes used as key into OrgDb
dmel_test.genelist

# lookup tables mapping gene list to other accessions
dmel_test.ACCNUM.csv
dmel_test.ALIAS.csv
dmel_test.ENSEMBL.csv
dmel_test.ENSEMBLPROT.csv
dmel_test.ENSEMBLTRANS.csv
dmel_test.ENTREZID.csv
dmel_test.ENZYME.csv
dmel_test.EVIDENCEALL.csv
dmel_test.EVIDENCE.csv
dmel_test.FLYBASECG.csv
dmel_test.FLYBASE.csv
dmel_test.FLYBASEPROT.csv
dmel_test.GENENAME.csv
dmel_test.GOALL.csv
dmel_test.GO.csv
dmel_test.MAP.csv
dmel_test.ONTOLOGYALL.csv
dmel_test.ONTOLOGY.csv
dmel_test.PATH.csv
dmel_test.PMID.csv
dmel_test.REFSEQ.csv
dmel_test.SYMBOL.csv
dmel_test.UNIGENE.csv
dmel_test.UNIPROT.csv
```

And for example `head dmel_test.SYMBOL.csv`:

```
"ENSEMBL","SYMBOL"
"FBgn0000061","al"
"FBgn0000442","Pkg21D"
"FBgn0000497","ds"
"FBgn0001142","Gs1"
"FBgn0002121","l(2)gl"
"FBgn0002563","Lsp1beta"
"FBgn0002593","RpLP1"
"FBgn0002931","net"
"FBgn0002936","ninaA"
```