### PR TITLE
adds a sort when creating chromsizes

### DIFF
--- a/references.snakefile
+++ b/references.snakefile
@@ -114,7 +114,8 @@ rule chromsizes:
         '&& picard CreateSequenceDictionary R={input} O={output}.tmp '
         '&& grep "^@SQ" {output}.tmp '
         '''| awk '{{print $2, $3}}' '''
-        '| sed "s/SN://g;s/ LN:/\\t/g" > {output} '
+        '| sed "s/SN://g;s/ LN:/\\t/g" '
+        '| sort -k1,1 > {output} '
         '&& rm -f {output}.tmp '
 
 


### PR DESCRIPTION
Found that chromsizes was not playing well with pybedtools because it was not sorted correctly. Just added as simple `sort -k1,1` to the command.