### PR TITLE
refactor into common.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:
-  - travis_wait ci/travis-run.sh
+  - travis_wait 30 ci/travis-run.sh
 env:
   global:
     - ENCRYPTION_LABEL: "7472da9c29f2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - export JAVA_HOME=
   - export TMPDIR=/tmp
 script:
-  - ci/travis-run.sh
+  - travis_wait ci/travis-run.sh
 env:
   global:
     - ENCRYPTION_LABEL: "7472da9c29f2"

--- a/4c.snakefile
+++ b/4c.snakefile
@@ -7,11 +7,7 @@ from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common
 
-TMPDIR = tempfile.gettempdir()
-JOBID = os.getenv('SLURM_JOBID')
-if JOBID:
-    TMPDIR = os.path.join('/lscratch', JOBID)
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(TMPDIR))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
 include: 'references.snakefile'

--- a/4c.snakefile
+++ b/4c.snakefile
@@ -17,8 +17,7 @@ if references_dir is None:
     raise ValueError('No references dir specified')
 config['references_dir'] = references_dir
 
-sampletable = pd.read_table(config['sampletable'])
-samples = sampletable.ix[:, 0]
+samples, sampletable = common.get_sampletable(config)
 assembly = config['assembly']
 refdict, conversion_kwargs = common.references_dict(config)
 

--- a/ci/travis-run.sh
+++ b/ci/travis-run.sh
@@ -28,7 +28,7 @@ case $TYPE in
       -j2 -T -k -p -r
     ;;
   pytest)
-    source activate lcdb-wf-test && py.test wrappers/test -n2 -v
+    source activate lcdb-wf-test && py.test wrappers/test -v
     ;;
   docs)
     ci/build-docs.sh

--- a/ci/travis-run.sh
+++ b/ci/travis-run.sh
@@ -21,6 +21,7 @@ case $TYPE in
     ;;
   rnaseq.snakefile)
     source activate lcdb-wf-test && \
+      conda --version && \
       snakemake -s rnaseq.snakefile \
       --configfile config/test_config.yaml \
       --use-conda \

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -20,7 +20,7 @@ bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
 export PATH="$CONDA_DIR/bin:$PATH"
 
 # See https://github.com/conda/conda/issues/5536
-conda install -y "conda<4.3" "python=3.5"
+conda install -y "conda<4.3"
 
 # Add channels in the specified order.
 conda config --add channels conda-forge

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -20,7 +20,7 @@ bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
 export PATH="$CONDA_DIR/bin:$PATH"
 
 # See https://github.com/conda/conda/issues/5536
-conda install "conda<4.3"
+conda install -y "conda<4.3"
 
 # Add channels in the specified order.
 conda config --add channels conda-forge

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -35,7 +35,7 @@ conda config --add channels bioconda
 conda config --add channels lcdb
 
 echo "Building environment $ENVNAME"
-conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
+conda create -n $ENVNAME -y --file requirements.txt \
     | grep -v " Time: "
 
 source activate $ENVNAME

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -19,10 +19,18 @@ bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
 
 export PATH="$CONDA_DIR/bin:$PATH"
 
+# See https://github.com/conda/conda/issues/5536
+conda install "conda<4.3"
+
 # Add channels in the specified order.
 conda config --add channels conda-forge
 conda config --add channels defaults
-conda config --add channels r
+
+# Recently bioconda helped migrate a ton of R packages from the `r` channel to
+# the `conda-forge` channel. See https://github.com/conda/conda/issues/5536 for
+# why the r channel needs to be removed...
+
+# conda config --add channels r
 conda config --add channels bioconda
 conda config --add channels lcdb
 
@@ -30,12 +38,5 @@ echo "Building environment $ENVNAME"
 conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
     | grep -v " Time: "
 
-# We were getting timeouts when building the RNA-seq environment in the context
-# of a snakefile's environment building step, since there was no output for
-# a long time. To try to help alleviate this, we try pre-caching the
-# environment here:
-conda env create --file config/envs/R_rnaseq.yaml -n tmp
-
 source activate $ENVNAME
-
 python ci/get-data.py

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -29,14 +29,18 @@ conda config --add channels defaults
 # Recently bioconda helped migrate a ton of R packages from the `r` channel to
 # the `conda-forge` channel. See https://github.com/conda/conda/issues/5536 for
 # why the r channel needs to be removed...
-
 # conda config --add channels r
 conda config --add channels bioconda
 conda config --add channels lcdb
 
+conda --version
+
 echo "Building environment $ENVNAME"
 conda create -n $ENVNAME -y --file requirements.txt \
     | grep -v " Time: "
+
+# try pre-caching rnaseq
+conda env create -n tmp --file config/envs/R_rnaseq.yaml
 
 source activate $ENVNAME
 python ci/get-data.py

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -30,5 +30,12 @@ echo "Building environment $ENVNAME"
 conda create -n $ENVNAME -y python=3.5 --file requirements.txt \
     | grep -v " Time: "
 
+# We were getting timeouts when building the RNA-seq environment in the context
+# of a snakefile's environment building step, since there was no output for
+# a long time. To try to help alleviate this, we try pre-caching the
+# environment here:
+conda env create --file config/envs/R_rnaseq.yaml -n tmp
+
 source activate $ENVNAME
+
 python ci/get-data.py

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -23,8 +23,8 @@ export PATH="$CONDA_DIR/bin:$PATH"
 conda install -y "conda<4.3"
 
 # Add channels in the specified order.
-conda config --add channels conda-forge
 conda config --add channels defaults
+conda config --add channels conda-forge
 
 # Recently bioconda helped migrate a ton of R packages from the `r` channel to
 # the `conda-forge` channel. See https://github.com/conda/conda/issues/5536 for

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -19,19 +19,18 @@ bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
 
 export PATH="$CONDA_DIR/bin:$PATH"
 
+cat > ~/.condarc <<EOF
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+  - lcdb
+default_channels:
+  - https://repo.continuum.io/pkgs/free
+EOF
+
 # See https://github.com/conda/conda/issues/5536
 conda install -y "conda<4.3"
-
-# Add channels in the specified order.
-conda config --add channels defaults
-conda config --add channels conda-forge
-
-# Recently bioconda helped migrate a ton of R packages from the `r` channel to
-# the `conda-forge` channel. See https://github.com/conda/conda/issues/5536 for
-# why the r channel needs to be removed...
-# conda config --add channels r
-conda config --add channels bioconda
-conda config --add channels lcdb
 
 conda --version
 

--- a/ci/travis-setup.sh
+++ b/ci/travis-setup.sh
@@ -20,7 +20,7 @@ bash Miniconda3-latest-Linux-x86_64.sh -f -b -p $CONDA_DIR
 export PATH="$CONDA_DIR/bin:$PATH"
 
 # See https://github.com/conda/conda/issues/5536
-conda install -y "conda<4.3"
+conda install -y "conda<4.3" "python=3.5"
 
 # Add channels in the specified order.
 conda config --add channels conda-forge

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -11,10 +11,11 @@ dependencies:
   - bioconductor-genomicfeatures
   - bioconductor-sva
   - bioconductor-tximport
-  - r-rmarkdown
   - pandoc
+  - r-codetools
+  - r-dt
   - r-knitrbootstrap
   - r-knitr
   - r-pheatmap
   - r-readr
-  - r-dt
+  - r-rmarkdown

--- a/config/envs/R_rnaseq.yaml
+++ b/config/envs/R_rnaseq.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - r
 
 dependencies:
   - bioconductor-deseq2

--- a/lib/common.py
+++ b/lib/common.py
@@ -281,9 +281,9 @@ def references_dict(config):
     return d, conversion_kwargs
 
 
-def setup_shell_for_biowulf(shell):
+def tempdir_for_biowulf():
     """
-    Sets up the snakemake.shell object for biowulf.
+    Get an appropriate tempdir.
 
     The NIH biowulf cluster allows nodes to have their own /lscratch dirs as
     local temp storage. However the particular dir depends on the slurm job ID,
@@ -292,19 +292,12 @@ def setup_shell_for_biowulf(shell):
     This makes it suitable for running locally or on other clusters, however if
     you need different behavior then a different function will need to be
     written.
-
-    Also explicitly sets the shell executable.
-
-    Parameters
-    ----------
-    shell : snakemake.shell object
     """
-    TMPDIR = tempfile.gettempdir()
-    JOBID = os.getenv('SLURM_JOBID')
-    if JOBID:
-        TMPDIR = os.path.join('/lscratch', JOBID)
-    shell.prefix('set -euo pipefail; export TMPDIR={};'.format(TMPDIR))
-    shell.executable('/bin/bash')
+    tmpdir = tempfile.gettempdir()
+    jobid = os.getenv('SLURM_JOBID')
+    if jobid:
+        tmpdir = os.path.join('/lscratch', jobid)
+    return tmpdir
 
 
 def get_references_dir(config):

--- a/lib/common.py
+++ b/lib/common.py
@@ -362,6 +362,7 @@ def get_references_dir(config):
     if references_dir is None:
         raise ValueError('No references dir specified')
     config['references_dir'] = references_dir
+    return references_dir
 
 
 def get_sampletable(config):

--- a/lib/common.py
+++ b/lib/common.py
@@ -1,9 +1,11 @@
 import os
+import tempfile
 import yaml
+import pandas
 from Bio import SeqIO
 import gzip
 from lcdblib.utils.imports import resolve_name
-from lcdblib.snakemake import aligners, helpers
+from lcdblib.snakemake import aligners
 from snakemake.shell import shell
 
 
@@ -18,6 +20,12 @@ def gzipped(tmpfiles, outfile):
 
 
 def cat(tmpfiles, outfile):
+    """
+    Simple concatenation of files.
+
+    Note that gzipped files can be concatenated as-is without un- and re-
+    compressing.
+    """
     shell('cat {tmpfiles} > {outfile}')
 
 
@@ -57,9 +65,29 @@ def download_and_postprocess(outfile, config, assembly, tag, type_):
     """
     Given an output file, figure out what to do based on the config.
 
+    Parameters
+    ----------
+    outfile : str
+
+    config : dict
+
+    assembly : str
+        Which assembly to use. Must be a key in the "references" section of the
+        config.
+
+    tag : str
+        Which tag for the assembly to use. Must be a tag for the assembly in the config
+
+    type_ : str
+        A supported references type (gtf, fasta) to use.
+
+    Notes
+    -----
+
     This function:
 
-     - uses assembly, tag, type_ as a key into the config dict to figure out:
+     - uses `assembly`, `tag`, `type_` as a key into the config dict to figure
+       out:
          - what postprocessing function (if any) was specified along with
            its optional args
          - the URL[s] to download
@@ -68,10 +96,32 @@ def download_and_postprocess(outfile, config, assembly, tag, type_):
      - calls the imported function using the tempfile[s] and outfile plus
        any additional specified arguments.
 
-    If defined, the function must assume a list of input gzipped files and must
-    create the gzipped output file (whose name is given as its 2nd input arg).
+
+    The function must have one of the following two signatures::
+
+        def func(infiles, outfile):
+            pass
+
+    or::
+
+        def func(infiles, outfile, *args):
+            pass
+
+
+    `infiles` contains the list of temporary files downloaded from the URL or
+    URLs specified.
+
+    `outfile` is a gzipped file expected to be created by the function.
+
+    The function is specified as a string that resolves to an importable
+    function, e.g., `lib.postprocess.dm6.fix` is a function called `fix` in the
+    file `lib/postprocess/dm6.py`.
+
+    If specified in the config as a dict, it must have `function` and `args`
+    keys. The `function` key indicates the importable path to the function, and
+    `args` can be a string or list of arguments that will be provided as
+    additional args to a function with the second kind of signature above.
     """
-    references_dir = get_references_dir(config)
 
     def default_postprocess(origfn, newfn):
         """
@@ -79,9 +129,6 @@ def download_and_postprocess(outfile, config, assembly, tag, type_):
         to the new.
         """
         shell("mv {origfn} {newfn}")
-
-    base = os.path.relpath(outfile, references_dir)
-    basename = os.path.basename(outfile)
 
     block = config['references'][assembly][tag][type_]
 
@@ -126,15 +173,18 @@ def download_and_postprocess(outfile, config, assembly, tag, type_):
                 shell('rm {i}')
 
 
-def get_references_dir(config):
-    references_dir = os.environ.get('REFERENCES_DIR', config.get('references_dir', None))
-    if references_dir is None:
-        raise ValueError('References dir not set')
-    return references_dir
-
-
 def references_dict(config):
     """
+    Reformats the config file's reference section into a more practical form.
+
+    Files can be referenced as `d[assembly][tag][type]`.
+
+    Parameters
+    ----------
+    config : dict
+
+    Notes
+    -----
     The config file is designed to be easy to edit and use from the user's
     standpoint. But it's not so great for practical usage. Here we convert the
     config file which has the format::
@@ -186,8 +236,6 @@ def references_dict(config):
     ... }), d
     >>> os.unlink('tmp')
 
-    With this new dictionary, other parts of the config or snakemake rules can
-    access the files by d[assembly][tag][type].
     """
     if isinstance(config, str):
         config = yaml.load(open(config))
@@ -201,7 +249,6 @@ def references_dict(config):
         'kallisto': '.idx',
         'salmon': '/hash.bin'
     }
-
 
     conversion_extensions = {
         'intergenic': '.intergenic.gtf',
@@ -259,7 +306,7 @@ def references_dict(config):
 
                         conversion_kwargs[output] = kwargs
 
-                if type_== 'fasta':
+                if type_ == 'fasta':
                     # Add indexes if specified
                     indexes = block.get('indexes', [])
                     for index in indexes:
@@ -318,6 +365,15 @@ def get_references_dir(config):
 
 
 def get_sampletable(config):
+    """
+    Returns the sample IDs and the parsed sampletable.
+
+    The sample IDs are assumed to be the first column of the sampletable.
+
+    Parameters
+    ----------
+    config : dict
+    """
     sampletable = pandas.read_table(config['sampletable'])
     samples = sampletable.iloc[:, 0]
     return samples, sampletable

--- a/references.snakefile
+++ b/references.snakefile
@@ -6,21 +6,19 @@ from snakemake.utils import makedirs
 from lcdblib.utils.imports import resolve_name
 from lcdblib.utils import utils
 from lcdblib.snakemake import aligners, helpers
-from lib.common import download_and_postprocess, references_dict, get_references_dir
+from lib import common
 
-shell.executable('/bin/bash')
+common.setup_shell_for_biowulf(shell)
+references_dir = common.get_references_dir(config)
+refdict, conversion_kwargs = common.references_dict(config)
 
-localrules: symlink_fasta_to_index_dir, chromsizes
+makedirs([references_dir, os.path.join(references_dir, 'logs')])
 
-HERE = str(srcdir('.'))
 
 def wrapper_for(path):
     return 'file:' + os.path.join('wrappers', 'wrappers', path)
 
-references_dir = get_references_dir(config)
-makedirs([references_dir, os.path.join(references_dir, 'logs')])
-
-refdict, conversion_kwargs = references_dict(config)
+localrules: symlink_fasta_to_index_dir, chromsizes
 
 rule all_references:
     input: utils.flatten(refdict)
@@ -31,7 +29,7 @@ rule all_references:
 rule download_and_process:
     output: temporary('{references_dir}/{assembly}/{tag}/{_type}/{assembly}_{tag}.{_type}.gz')
     run:
-        download_and_postprocess(output[0], config, wildcards.assembly, wildcards.tag, wildcards._type)
+        common.download_and_postprocess(output[0], config, wildcards.assembly, wildcards.tag, wildcards._type)
 
 
 rule unzip:

--- a/references.snakefile
+++ b/references.snakefile
@@ -8,7 +8,8 @@ from lcdblib.utils import utils
 from lcdblib.snakemake import aligners, helpers
 from lib import common
 
-common.setup_shell_for_biowulf(shell)
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.executable('/bin/bash')
 references_dir = common.get_references_dir(config)
 refdict, conversion_kwargs = common.references_dict(config)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# atropos ==1.0.23
+atropos ==1.1.5
 bioconductor-dupradar ==1.2.2
 biopython ==1.69
 bowtie2 ==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atropos ==1.1.5
-bioconductor-dupradar ==1.2.2
+# bioconductor-dupradar ==1.2.2
 biopython ==1.69
 bowtie2 ==2.3.2
 cutadapt ==1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # atropos ==1.0.23
-atropos ==1.0.23
 bioconductor-dupradar ==1.2.2
 biopython ==1.69
 bowtie2 ==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atropos ==1.1.5
-# bioconductor-dupradar ==1.2.2
+bioconductor-dupradar ==1.2.2
 biopython ==1.69
 bowtie2 ==2.3.2
 cutadapt ==1.13
@@ -16,9 +16,10 @@ pandas ==0.20.2
 picard ==2.9.2
 pysam == 0.11.2.2
 pytest ==3.1.1
-pytest-xdist ==1.14
-# python ==3.5
-# r ==3.3.2
+pytest-xdist ==1.18
+python ==3.6
+r ==3.3.2
+# r-kernsmooth ==2.23
 # r-essentials ==1.5.2
 # rseqc ==2.6.4
 salmon ==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ picard ==2.9.2
 pysam == 0.11.2.2
 pytest ==3.1.1
 pytest-xdist ==1.14
-python ==3.5
+# python ==3.5
 # r ==3.3.2
 # r-essentials ==1.5.1
 # rseqc ==2.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pytest ==3.1.1
 pytest-xdist ==1.14
 # python ==3.5
 # r ==3.3.2
-# r-essentials ==1.5.1
+# r-essentials ==1.5.2
 # rseqc ==2.6.4
 salmon ==0.8.2
 samtools ==1.4.1

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -105,8 +105,8 @@ rule targets:
             [targets['multiqc']] +
             utils.flatten(targets['featurecounts']) +
             utils.flatten(targets['markduplicates']) +
-            utils.flatten(targets['dupradar']) +
             utils.flatten(targets['salmon']) +
+            #utils.flatten(targets['dupradar']) +
             utils.flatten(targets['rseqc']) +
             utils.flatten(targets['collectrnaseqmetrics']) +
             utils.flatten(targets['bigwig']) +

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -17,7 +17,7 @@ shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_bi
 shell.executable('/bin/bash')
 common.get_references_dir(config)
 
-sampletable, samples = common.get_sampletable(config)
+samples, sampletable = common.get_sampletable(config)
 refdict, conversion_kwargs = common.references_dict(config)
 
 assembly = config['assembly']

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -13,7 +13,8 @@ from lib import common
 
 include: 'references.snakefile'
 
-common.setup_shell_for_biowulf(shell)
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.executable('/bin/bash')
 common.get_references_dir(config)
 
 sampletable, samples = common.get_sampletable(config)

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -393,6 +393,8 @@ rule bigwig_neg:
     output: patterns['bigwig']['neg']
     params:
         extra = '--minMappingQuality 20 --ignoreDuplicates --smoothLength 10 --filterRNAstrand reverse --normalizeUsingRPKM'
+    log:
+        patterns['bigwig']['neg'] + '.log'
     wrapper: wrapper_for('deeptools/bamCoverage')
 
 
@@ -406,6 +408,8 @@ rule bigwig_pos:
     output: patterns['bigwig']['pos']
     params:
         extra = '--minMappingQuality 20 --ignoreDuplicates --smoothLength 10 --filterRNAstrand forward --normalizeUsingRPKM'
+    log:
+        patterns['bigwig']['pos'] + '.log'
     wrapper: wrapper_for('deeptools/bamCoverage')
 
 

--- a/wrappers/test/test_dupradar.py
+++ b/wrappers/test/test_dupradar.py
@@ -30,7 +30,7 @@ def sample1_se_dupradar(sample1_se_bam_markdups, annotation, tmpdir_factory):
         }
     )
     tmpdir = str(tmpdir_factory.mktemp('dupradar_fixture'))
-    run(dpath('../wrappers/dupradar'), snakefile, None, input_data_func, tmpdir, use_conda=True)
+    run(dpath('../wrappers/dupradar'), snakefile, None, input_data_func, tmpdir, use_conda=False)
     mapping = dict(
         density_scatter='sample1.density_scatter.png',
         expression_histogram='sample1.expression_histogram.png',

--- a/wrappers/test/test_dupradar.py
+++ b/wrappers/test/test_dupradar.py
@@ -30,7 +30,7 @@ def sample1_se_dupradar(sample1_se_bam_markdups, annotation, tmpdir_factory):
         }
     )
     tmpdir = str(tmpdir_factory.mktemp('dupradar_fixture'))
-    run(dpath('../wrappers/dupradar'), snakefile, None, input_data_func, tmpdir)
+    run(dpath('../wrappers/dupradar'), snakefile, None, input_data_func, tmpdir, use_conda=True)
     mapping = dict(
         density_scatter='sample1.density_scatter.png',
         expression_histogram='sample1.expression_histogram.png',

--- a/wrappers/test/test_picard.py
+++ b/wrappers/test/test_picard.py
@@ -22,7 +22,7 @@ def sample1_se_bam_markdups(sample1_se_bam, tmpdir_factory):
         }
     )
     tmpdir = str(tmpdir_factory.mktemp('markduplicates_fixture'))
-    run(dpath('../wrappers/picard/markduplicates'), snakefile, None, input_data_func, tmpdir)
+    run(dpath('../wrappers/picard/markduplicates'), snakefile, None, input_data_func, tmpdir, use_conda=True)
     return {
             'bam': os.path.join(tmpdir, 'sample1.dupsmarked.bam'),
             'metrics': os.path.join(tmpdir, 'sample1.dupmetrics.txt')
@@ -57,7 +57,7 @@ def test_picard_collectrnaseqmetrics_se(sample1_se_tiny_bam, annotation_refflat,
     def check():
         assert '## METRICS CLASS' in open('sample1.metrics').read()
 
-    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir)
+    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir, use_conda=True)
 
 
 def test_picard_collectrnaseqmetrics_se_plot(sample1_se_tiny_bam, annotation_refflat, tmpdir):
@@ -83,7 +83,7 @@ def test_picard_collectrnaseqmetrics_se_plot(sample1_se_tiny_bam, annotation_ref
     def check():
         assert '## METRICS CLASS' in open('sample1.metrics').read()
 
-    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir)
+    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir, use_conda=True)
 
 
 @pytest.mark.xfail
@@ -113,4 +113,4 @@ def test_picard_collectrnaseqmetrics_too_small_heap(sample1_se_tiny_bam, annotat
     def check():
         assert '## METRICS CLASS' in open('sample1.metrics').read()
 
-    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir)
+    run(dpath('../wrappers/picard/collectrnaseqmetrics'), snakefile, check, input_data_func, tmpdir, use_conda=True)

--- a/wrappers/wrappers/atropos/environment.yaml
+++ b/wrappers/wrappers/atropos/environment.yaml
@@ -1,4 +1,4 @@
 channels:
   - bioconda
 dependencies:
-  - atropos ==1.0.23
+  - atropos ==1.1.5

--- a/wrappers/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/wrappers/bowtie2/align/environment.yaml
@@ -5,4 +5,3 @@ dependencies:
   - bowtie2 ==2.3.2
   - samtools ==1.4.1
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/bowtie2/build/environment.yaml
+++ b/wrappers/wrappers/bowtie2/build/environment.yaml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - bowtie2 ==2.3.2
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/demo/environment.yaml
+++ b/wrappers/wrappers/demo/environment.yaml
@@ -2,4 +2,3 @@ channels:
   - lcdb
 dependencies:
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - lcdb
 dependencies:
   - bioconductor-dupradar ==1.2.2
-  - r-kernsmooth
-  - r-base==3.3.2
+  - r-kernsmooth ==2.23
+  - r ==3.3.2
   - lcdblib ==0.1.2.post
   - ghostscript ==9.18

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - lcdb
 dependencies:
   - bioconductor-dupradar ==1.2.2
+  - r-kernsmooth
   - r-base==3.3.2
   - lcdblib ==0.1.2.post
   - ghostscript ==9.18

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -5,4 +5,3 @@ dependencies:
   - bioconductor-dupradar ==1.2.2
   - lcdblib ==0.1.2.post
   - ghostscript ==9.18
-  - python ==3.5

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -3,5 +3,6 @@ channels:
   - lcdb
 dependencies:
   - bioconductor-dupradar ==1.2.2
+  - r-base==3.3.2
   - lcdblib ==0.1.2.post
   - ghostscript ==9.18

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
   - lcdb
 dependencies:
   - bioconductor-dupradar ==1.2.2

--- a/wrappers/wrappers/fastq_screen/environment.yaml
+++ b/wrappers/wrappers/fastq_screen/environment.yaml
@@ -5,4 +5,3 @@ dependencies:
   - fastq-screen ==0.11.1
   - bowtie2 ==2.3.2
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/hisat2/align/environment.yaml
+++ b/wrappers/wrappers/hisat2/align/environment.yaml
@@ -5,4 +5,3 @@ dependencies:
   - hisat2 ==2.0.5
   - samtools ==1.4.1
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/hisat2/build/environment.yaml
+++ b/wrappers/wrappers/hisat2/build/environment.yaml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - hisat2 ==2.0.5
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/multiqc/environment.yaml
+++ b/wrappers/wrappers/multiqc/environment.yaml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - multiqc ==1.0
   - lcdblib ==0.1.2.post
-  - python ==3.5

--- a/wrappers/wrappers/picard/collectrnaseqmetrics/environment.yaml
+++ b/wrappers/wrappers/picard/collectrnaseqmetrics/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
 dependencies:
   - picard ==2.9.2
   - r ==3.3.2

--- a/wrappers/wrappers/picard/markduplicates/environment.yaml
+++ b/wrappers/wrappers/picard/markduplicates/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
 dependencies:
   - picard ==2.9.2
   - r ==3.3.2

--- a/wrappers/wrappers/rseqc/bam_stat/environment.yaml
+++ b/wrappers/wrappers/rseqc/bam_stat/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/bam_stat/environment.yaml
+++ b/wrappers/wrappers/rseqc/bam_stat/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
 dependencies:
   - rseqc ==2.6.4
-  - r-essentials ==1.5.1
+  - r-essentials ==1.5.2
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
   - defaults
   - conda-forge
 dependencies:

--- a/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -1,8 +1,6 @@
 channels:
   - bioconda
-  - defaults
   - conda-forge
 dependencies:
   - rseqc ==2.6.4
-  - r-essentials ==1.5.2
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/infer_experiment/environment.yaml
+++ b/wrappers/wrappers/rseqc/infer_experiment/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/infer_experiment/environment.yaml
+++ b/wrappers/wrappers/rseqc/infer_experiment/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/tin/environment.yaml
+++ b/wrappers/wrappers/rseqc/tin/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2

--- a/wrappers/wrappers/rseqc/tin/environment.yaml
+++ b/wrappers/wrappers/rseqc/tin/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - r
 dependencies:
   - rseqc ==2.6.4
   - pysam == 0.11.2.2


### PR DESCRIPTION
An attempt to clean up individual snakefiles' boilerplate by having them import stuff from `lib.common` for setting up the shell, getting sampletables, and reference dirs.

Also improves docstrings.

**edit Jun 21 2017:** turns out bumping version was a huge pain. See https://github.com/lcdb/lcdblib/pull/41 for some details. I also figured out here that we need to pin R in order to avoid a readline error, and that the dupRadar package doesn't specify that it requires KernSmooth which used to be a built-in package but is no longer in the most recent R. 