### PR TITLE
rRNA

### DIFF
--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -122,19 +122,18 @@ rule targets:
         )
 
 
+if 'orig_filename' in sampletable.columns:
+    rule symlinks:
+        """
+        Symlinks files over from original filename
+        """
+        input: lambda wc: sampletable.set_index(sampletable.columns[0])['orig_filename'].to_dict()[wc.sample]
+        output: patterns['fastq']
+        run:
+            common.relative_symlink(input[0], output[0])
 
-rule symlinks:
-    """
-    Symlinks files over from original filename
-    """
-    input: lambda wc: sampletable.set_index(sampletable.columns[0])['orig_filename'].to_dict()[wc.sample]
-    output: patterns['fastq']
-    run:
-        common.relative_symlink(input[0], output[0])
-
-
-rule symlink_targets:
-    input: targets['fastq']
+    rule symlink_targets:
+        input: targets['fastq']
 
 rule cutadapt:
     """


### PR DESCRIPTION
This PR adds rRNA alignment to a bowtie2 index along with a custom table that is read in by MultiQC.

I had written this while I was still confused about the MultiQC fastq_screen output, but after fixing that I'm not sure this is super useful. Then again it's easy enough to comment-out if it's unneeded, so I'm keeping it in.

This also adds a rule to symlink fastqs over from, say, where they were transferred from the core. But only if the fastqs don't already exist and if there's a `orig_filename` column in the sampletable.

I also realized, after staring at some MultiQC reports, that we were not removing unmapped reads in the hisat2 rule. That's fixed here.
