### PR TITLE
Increment FlyBase to r6.16

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -20,17 +20,17 @@ assembly: 'dmel'
 
 aligner:
     index: 'hisat2'
-    tag: 'r6-11'
+    tag: 'r6-16'
 
 rrna:
     index: 'bowtie2'
     tag: 'rRNA'
 
 gtf:
-    tag: "r6-11"
+    tag: "r6-16"
 
 kallisto:
-    tag: "r6-11_transcriptome"
+    tag: "r6-16_transcriptome"
 
 
 # references has the structure:
@@ -105,6 +105,54 @@ references:
       fasta:
         url:
           - 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-chromosome-r6.11.fasta.gz'
+          -  'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
+        postprocess:
+          function: "lib.postprocess.merge.file_merge"
+          args:
+            - "lib.postprocess.dm6.fasta_postprocess"
+            - "lib.postprocess.ercc.fasta_postprocess"
+        indexes:
+          - 'bowtie2'
+          - 'hisat2'
+
+    r6-16:
+      gtf:
+        url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/gtf/dmel-all-r6.16.gtf.gz'
+        postprocess: "lib.postprocess.dm6.gtf_lib.postprocess"
+        conversions:
+          - 'refflat'
+          - 'gffutils'
+
+      fasta:
+        url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/fasta/dmel-all-chromosome-r6.16.fasta.gz'
+        postprocess: "lib.postprocess.dm6.fasta_lib.postprocess"
+        indexes:
+          - 'bowtie2'
+          - 'hisat2'
+
+    r6-16_transcriptome:
+      fasta:
+        url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/fasta/dmel-all-transcript-r6.16.fasta.gz'
+        indexes:
+          - 'kallisto'
+
+    r6-16_and_ercc:
+      gtf:
+        url:
+          - 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/gtf/dmel-all-r6.16.gtf.gz'
+          - 'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
+        postprocess:
+          function: "lib.postprocess.merge.file_merge"
+          args:
+            - "lib.postprocess.dm6.gtf_postprocess"
+            - "lib.postprocess.ercc.gtf_postprocess"
+        conversions:
+          - 'refflat'
+          - 'gffutils'
+
+      fasta:
+        url:
+          - 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/fasta/dmel-all-chromosome-r6.16.fasta.gz'
           -  'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
         postprocess:
           function: "lib.postprocess.merge.file_merge"

--- a/config/config.yml
+++ b/config/config.yml
@@ -49,7 +49,7 @@ references:
     default:
       fasta:
         url: 'http://hgdownload.cse.ucsc.edu/goldenPath/sacCer3/bigZips/chromFa.tar.gz'
-        postprocess: 'lib.postprocess.sacCer3.fasta_lib.postprocess'
+        postprocess: 'lib.postprocess.sacCer3.fasta_postprocess'
         indexes:
             - 'bowtie2'
 
@@ -58,14 +58,14 @@ references:
 
       gtf:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/gtf/dmel-all-r6.11.gtf.gz'
-        postprocess: "lib.postprocess.dm6.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.gtf_postprocess"
         conversions:
           - 'refflat'
           - 'gffutils'
 
       fasta:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.11_FB2016_03/fasta/dmel-all-chromosome-r6.11.fasta.gz'
-        postprocess: "lib.postprocess.dm6.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.fasta_postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
@@ -118,14 +118,14 @@ references:
     r6-16:
       gtf:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/gtf/dmel-all-r6.16.gtf.gz'
-        postprocess: "lib.postprocess.dm6.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.gtf_postprocess"
         conversions:
           - 'refflat'
           - 'gffutils'
 
       fasta:
         url: 'ftp://ftp.flybase.net/genomes/Drosophila_melanogaster/dmel_r6.16_FB2017_03/fasta/dmel-all-chromosome-r6.16.fasta.gz'
-        postprocess: "lib.postprocess.dm6.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.dm6.fasta_postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
@@ -281,7 +281,7 @@ references:
     default:
       fasta:
         url: 'ftp://igenome:G3nom3s4u@ussd-ftp.illumina.com/PhiX/Illumina/RTA/PhiX_Illumina_RTA.tar.gz'
-        postprocess: "lib.postprocess.phix.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.phix.fasta_postprocess"
         indexes:
           - 'bowtie2'
 
@@ -289,29 +289,29 @@ references:
     srm2374:
       fasta:
         url: 'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
-        postprocess: "lib.postprocess.ercc.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.ercc.fasta_postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
       gtf:
         url: 'https://www-s.nist.gov/srmors/certificates/documents/SRM2374_Sequence_v1.FASTA'
-        postprocess: "lib.postprocess.ercc.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.ercc.gtf_postprocess"
 
     fisher92:
       fasta:
         url: 'https://tools.thermofisher.com/content/sfs/manuals/ERCC92.zip'
-        postprocess: "lib.postprocess.erccFisher.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.erccFisher.fasta_postprocess"
         indexes:
           - 'bowtie2'
           - 'hisat2'
       gtf:
         url: 'https://tools.thermofisher.com/content/sfs/manuals/ERCC92.zip'
-        postprocess: "lib.postprocess.erccFisher.gtf_lib.postprocess"
+        postprocess: "lib.postprocess.erccFisher.gtf_postprocess"
 
   adapters:
     default:
       fasta:
         url: 'https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/adapters.fa'
-        postprocess: "lib.postprocess.adapters.fasta_lib.postprocess"
+        postprocess: "lib.postprocess.adapters.fasta_postprocess"
         indexes:
           - 'bowtie2'


### PR DESCRIPTION
This PR increments to the latest FlyBase version (r6.16). It also modifies method names for the post-processing steps that appear to have changed.