### PR TITLE
add rnaseq trackhub and config

### DIFF
--- a/config/hub_config.yml
+++ b/config/hub_config.yml
@@ -1,0 +1,38 @@
+hub:
+  name: 'example-rnaseq'
+  short_label: 'example-rnaseq'
+  long_label: 'example-rnaseq'
+  email: 'dalerr@niddk.nih.gov'
+  genome: 'dm6'
+  url: 'https://example.com/hub.txt'
+  remote_fn: '/www-data/trackhub/hub.txt'
+
+upload:
+  host: localhost
+  user: $USER
+  rsync_options: '-vprLt --progress'
+  staging: staging
+
+subgroups:
+  # The subgroups to use, as specified in sampletable.tsv. The order matters;
+  # they will be used to create dimensions.
+  columns:
+    - group
+    - samplename
+
+  # the default sort order can be independent of the columns. Anything missing
+  # here will inherit sorting from `columns` above.
+  sort_order:
+    - samplename
+
+# Colors and regular expressions to search against samplenames. These use `regex.search`
+# instead of `regex.match`, so if the pattern can be found anywhere. 
+#
+# Note that this is a list of one-key dicts. The list is prioritized such that
+# the first pattern to match a sample wins. The value of each single-value dict
+# is itself a list, so you can easily group tracks by color.
+colors:
+  - "#4c9985":
+    - control
+  - "#003366":
+    - treatment

--- a/rnaseq_trackhub.py
+++ b/rnaseq_trackhub.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+"""
+Build and upload a track hub of RNA-seq signals, with samples, sort order,
+selection matrix, colors, and server info configured in a hub config file.
+
+This module assumes a particular filename pattern and whether or not bigwigs
+are stranded.  Such assumptions are indicated in the comments below.
+"""
+
+import re
+import os
+import pandas
+import yaml
+import matplotlib
+from trackhub.helpers import sanitize
+from trackhub import CompositeTrack, ViewTrack, SubGroupDefinition, Track, default_hub
+from trackhub.upload import upload_hub
+
+
+# Access configured options. See comments in example hub_config.yaml for
+# details
+config = yaml.load(open('config/config.yml'))
+hub_config = yaml.load(open(config['hub_config']))
+
+hub, genomes_file, genome, trackdb = default_hub(
+    hub_name=hub_config['hub']['name'],
+    short_label=hub_config['hub']['short_label'],
+    long_label=hub_config['hub']['long_label'],
+    email=hub_config['hub']['email'],
+    genome=hub_config['hub']['genome']
+)
+
+hub.url = hub_config['hub']['url']
+hub.remote_fn = hub_config['hub']['remote_fn']
+
+# Set up subgroups based on the configured columns
+df = pandas.read_table(config['sampletable'])
+cols = hub_config['subgroups']['columns']
+subgroups = []
+for col in cols:
+    unique = list(df[col].unique())
+    s = SubGroupDefinition(
+        name=sanitize(col, strict=True),
+        label=col,
+        mapping={
+            sanitize(i, strict=True): sanitize(i, strict=False)
+            for i in unique}
+    )
+    subgroups.append(s)
+
+# also add direction as a subgroup
+# ASSUMPTION: stranded bigwigs were created
+subgroups.append(
+    SubGroupDefinition(
+        name='strand',
+        label='strand',
+        mapping={'pos': 'pos', 'neg': 'neg'}))
+
+
+def dimensions_from_subgroups(s):
+    """
+    Given a sorted list of subgroups, return a string appropriate to provide as
+    a composite track's `dimensions` arg
+    """
+    letters = 'XYABCDEFGHIJKLMNOPQRSTUVWZ'
+    return ' '.join(['dim{0}={1}'.format(dim, sg.name) for dim, sg in zip(letters, s)])
+
+
+def filter_composite_from_subgroups(s):
+    """
+    Given a sorted list of subgroups, return a string appropriate to provide as
+    the a composite track's `filterComposite` argumen argumen
+    """
+    dims = []
+    for letter, sg in zip('ABCDEFGHIJKLMNOPQRSTUVWZ', s[2:]):
+        dims.append('dim{0}'.format(letter))
+    if dims:
+        return ' '.join(dims)
+
+# Identify the sort order based on the config, and create a string appropriate
+# for use as the `sortOrder` argument of a composite track.
+to_sort = hub_config['subgroups'].get('sort_order', [])
+to_sort += [sg.name for sg in subgroups if sg.name not in to_sort]
+sort_order = ' '.join([i + '=+' for i in to_sort])
+
+# Identify samples based on config and sampletable
+sample_dir = config['sample_dir']
+samples = df[df.columns[0]]
+
+composite = CompositeTrack(
+    name=hub_config['hub']['name'] + 'composite',
+    short_label='rnaseq composite',
+    long_label='rnaseq composite',
+    dimensions=dimensions_from_subgroups(subgroups),
+    filterComposite=filter_composite_from_subgroups(subgroups),
+    sortOrder=sort_order,
+    tracktype='bigWig')
+
+# ASSUMPTION: stranded bigwigs
+pos_signal_view = ViewTrack(
+    name='possignalviewtrack', view='possignal', visibility='full',
+    tracktype='bigWig', short_label='plus strand', long_label='plus strand signal')
+neg_signal_view = ViewTrack(
+    name='negsignalviewtrack', view='negsignal', visibility='full',
+    tracktype='bigWig', short_label='minus strand', long_label='minus strand signal')
+
+colors = hub_config.get('colors', [])
+
+
+def hex2rgb(h):
+    """
+    Given a hex color code, return a 0-255 RGB tuple as a CSV string, e.g.,
+    "#ff0000" -> "255,0,0"
+    """
+    return ','.join(map(lambda x: str(int(x * 255)), matplotlib.colors.hex2color(h)))
+
+
+def decide_color(samplename):
+    """
+    Look up the color dictionary in the config and return the first color that
+    matches `samplename`.
+    """
+    for cdict in hub_config.get('colors', []):
+        k = list(cdict.keys())
+        assert len(k) == 1
+        color = k[0]
+        v = cdict[color]
+        for pattern in v:
+            regex = re.compile(pattern)
+            if regex.search(samplename):
+                return hex2rgb(color)
+    return hex2rgb('#000000')
+
+
+for sample in df[df.columns[0]]:
+    # ASSUMPTION: stranded bigwigs
+    for direction in 'pos', 'neg':
+
+        # ASSUMPTION: bigwig filename pattern
+        bigwig = os.path.join(
+            sample_dir, sample,
+            sample + '.cutadapt.bam.{0}.bigwig'.format(direction))
+
+        subgroup = df[df.iloc[:, 0] == sample].to_dict('records')[0]
+        subgroup = {
+            sanitize(k, strict=True): sanitize(v, strict=True)
+            for k, v in subgroup.items()
+        }
+
+        # ASSUMPTION: stranded bigwigs
+        additional_kwargs = {}
+        subgroup['strand'] = direction
+        view = pos_signal_view
+        if direction == 'neg':
+            additional_kwargs['negateValues'] = 'on'
+            view = neg_signal_view
+
+        view.add_tracks(
+            Track(
+                name=sanitize(sample + os.path.basename(bigwig), strict=True),
+                short_label=sample + '_' + direction,
+                long_label=sample + '_' + direction,
+                tracktype='bigWig',
+                subgroups=subgroup,
+                local_fn=bigwig,
+                color=decide_color(sample),
+                altColor=decide_color(sample),
+                maxHeightPixels='8:25:100',
+                **additional_kwargs
+            )
+        )
+
+# Tie everything together
+composite.add_subgroups(subgroups)
+trackdb.add_tracks(composite)
+composite.add_view(pos_signal_view)
+composite.add_view(neg_signal_view)
+
+# Render and upload using settings from hub config file
+hub.render()
+kwargs = hub_config.get('upload', {})
+upload_hub(hub=hub, **kwargs)
+print(hub.url)


### PR DESCRIPTION
(I just mistakenly pushed this directly to master; I then reverted and then changed the repo settings so that master branch is protected)

This will build an RNA-seq track hub of bigwigs, with configuration for coloring, sorting, and organization on the hub config page.

Not sure where it should live yet. `downstream` maybe? This should also work with the chipseq workflow with minor modifications, so maybe it should be generalized to support different kinds of trackhubs? There are also some functions in here that could either be put in [trackhub proper](https://github.com/daler/trackhub) or could be part of a trackhub helpers module.

Edit: oh, and it needs tests too.