### PR TITLE
hotfix

### DIFF
--- a/downstream/rnaseq.Rmd
+++ b/downstream/rnaseq.Rmd
@@ -64,7 +64,7 @@ DESeqDataSetFromFeatureCounts <- function (sampleTable, directory='.', design,
 DESeqDataSetFromSalmon <- function (sampleTable, directory='.', design,
                                            ignoreRank=FALSE,  ...)
 {
-    txi <- tximport(sampleTable[, 'salmon.path'], type='salmon', reader=read_tsv, txOut=TRUE)
+    txi <- tximport(sampleTable[, 'salmon.path'], type='salmon', txOut=TRUE)
     object <- DESeqDataSetFromTximport(txi, colData=sampleTable[, -grepl('path', colnames(sampleTable)),
                                        drop=FALSE], design=design, ignoreRank, ...)
     return(object)

--- a/wrappers/wrappers/picard/collectrnaseqmetrics/environment.yaml
+++ b/wrappers/wrappers/picard/collectrnaseqmetrics/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - picard ==2.9.2
   - r-base ==3.3.2


### PR DESCRIPTION
picard/collectrnaseqmetrics was pulling in a broken version of R from defaults; adding `conda-forge` to the channels list fixed it.

Also since we're not pinning bioconductor-tximport in `config/envs/R_rnaseq.yaml`, the latest version of tximport came in and complained about an extra `reader=` arg.

This PR fixes both.