### PR TITLE
annotation hub uses tmpdir

### DIFF
--- a/references.snakefile
+++ b/references.snakefile
@@ -169,7 +169,7 @@ rule annotations:
     shell:
         '''Rscript -e "'''
         "library(AnnotationHub); "
-        "ah <- AnnotationHub(); "
+        "ah <- AnnotationHub(cache=$TMPDIR); "
         "db <- ah[['{params.ahkey}']]; "
         "gene.names <- read.table('{input}', stringsAsFactors=FALSE)[['V1']];"
         "for (col in columns(db)){{"

--- a/references.snakefile
+++ b/references.snakefile
@@ -169,7 +169,7 @@ rule annotations:
     shell:
         '''Rscript -e "'''
         "library(AnnotationHub); "
-        "ah <- AnnotationHub(cache=$TMPDIR); "
+        "ah <- AnnotationHub(cache='$TMPDIR'); "
         "db <- ah[['{params.ahkey}']]; "
         "gene.names <- read.table('{input}', stringsAsFactors=FALSE)[['V1']];"
         "for (col in columns(db)){{"


### PR DESCRIPTION
Addresses #53 by letting AnnotationHub use tmpdir when downloading its databases.