### PR TITLE
Dependency updates

### DIFF
--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -130,7 +130,7 @@ if 'orig_filename' in sampletable.columns:
         input: lambda wc: sampletable.set_index(sampletable.columns[0])['orig_filename'].to_dict()[wc.sample]
         output: patterns['fastq']
         run:
-            common.relative_symlink(input[0], output[0])
+            utils.make_relative_symlink(input[0], output[0])
 
     rule symlink_targets:
         input: targets['fastq']

--- a/wrappers/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/wrappers/bowtie2/align/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - bowtie2 ==2.3.2
   - samtools ==1.4.1
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/bowtie2/build/environment.yaml
+++ b/wrappers/wrappers/bowtie2/build/environment.yaml
@@ -2,5 +2,6 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - bowtie2 ==2.3.2
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/deeptools/plotFingerprint/environment.yaml
+++ b/wrappers/wrappers/deeptools/plotFingerprint/environment.yaml
@@ -2,4 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
+  - python=3
   - deeptools ==2.5.1

--- a/wrappers/wrappers/demo/environment.yaml
+++ b/wrappers/wrappers/demo/environment.yaml
@@ -1,4 +1,5 @@
 channels:
   - lcdb
 dependencies:
+  - python=3
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/dupradar/environment.yaml
+++ b/wrappers/wrappers/dupradar/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - bioconductor-dupradar ==1.2.2
   - r-kernsmooth ==2.23
   - r ==3.3.2

--- a/wrappers/wrappers/fastq_screen/environment.yaml
+++ b/wrappers/wrappers/fastq_screen/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - fastq-screen ==0.11.1
   - bowtie2 ==2.3.2
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/hisat2/align/environment.yaml
+++ b/wrappers/wrappers/hisat2/align/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - hisat2 ==2.0.5
   - samtools ==1.4.1
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/hisat2/build/environment.yaml
+++ b/wrappers/wrappers/hisat2/build/environment.yaml
@@ -2,5 +2,6 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - hisat2 ==2.0.5
   - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/multiqc/environment.yaml
+++ b/wrappers/wrappers/multiqc/environment.yaml
@@ -1,6 +1,5 @@
 channels:
   - bioconda
-  - lcdb
 dependencies:
-  - multiqc ==1.0
-  - lcdblib ==0.1.2.post
+  - networkx <2
+  - multiqc ==1.2

--- a/wrappers/wrappers/multiqc/wrapper.py
+++ b/wrappers/wrappers/multiqc/wrapper.py
@@ -1,11 +1,5 @@
-__author__ = "Ryan Dale"
-__copyright__ = "Copyright 2016, Ryan Dale"
-__email__ = "dalerr@niddk.nih.gov"
-__license__ = "MIT"
-
 import os
 from snakemake.shell import shell
-from lcdblib.utils import utils
 
 outdir = os.path.dirname(snakemake.output[0])
 if not outdir:
@@ -15,16 +9,15 @@ basename = os.path.basename(snakemake.output[0])
 extra = snakemake.params.get('extra', "")
 log = snakemake.log_fmt_shell()
 
-
 # MultiQC uses Click, which in turn complains if C.UTF-8 is not set
-with utils.temp_env(dict(LC_ALL='en_US.UTF-8', LC_LANG='en_US.UTF-8')) as env:
-    shell(
-        'multiqc '
-        '--quiet '
-        '--outdir {outdir} '
-        '--force '
-        '--filename {basename} '
-        '{extra} '
-        '{snakemake.params.analysis_directory} '
-        '{log}'
-    )
+shell(
+    'LC_ALL=en_US.UTF.8 LC_LANG=en_US.UTF-8 '
+    'multiqc '
+    '--quiet '
+    '--outdir {outdir} '
+    '--force '
+    '--filename {basename} '
+    '{extra} '
+    '{snakemake.params.analysis_directory} '
+    '{log}'
+)

--- a/wrappers/wrappers/samtools/merge/environment.yaml
+++ b/wrappers/wrappers/samtools/merge/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - bioconda
   - lcdb
 dependencies:
+  - python=3
   - samtools ==1.4.1
   - lcdblib
 


### PR DESCRIPTION
This PR affects environments, fixing the following issues:

1. if the conda installation is python2 (e.g., Miniconda2), then wrapper generation tries to use py27 even in cases where we have lcdblib (which is py3 only). So in those environment.yaml files, I've pinned `python =3`.

2. multiqc depends on spectra which depends on colormath which depends on networkx. The new version of networkx broke colormath, which in turn breaks multiqc. The fix is to pin networkx <2 in the multiqc environment

3. multiqc uses click, which very pointedly does not play nice with python3 (http://click.pocoo.org/5/python3/). We have been having problems getting it working in bioconda, so the latest multiqc versions are only available for py27. This was a problem as the wrapper also depended on the py3-only lcdblib. lcdblib was only used for the temporary environment, which can be reproduced with just sticking the env vars before the call. So now lcdblib no longer a dep and we can use multiqc versions build on py27.

cc @palmercd
