### PR TITLE
improve gffutils db creation

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -220,6 +220,17 @@ references:
         postprocess: 'lib.postprocess.hg38.strip_ensembl_version'
         conversions:
           - 'refflat'
+          - gffutils:
+              merge_strategy: 'merge'
+              id_spec:
+                  transcript: 'transcript_id'
+                  gene: 'gene_id'
+                  exon: 'exon_id'
+              gtf_transcript_key: 'transcript_id'
+              gtf_gene_key: 'gene_id'
+              disable_infer_genes: True
+              disable_infer_transcripts: True
+
 
     gencode-v25-transcriptome:
       fasta:

--- a/references.snakefile
+++ b/references.snakefile
@@ -2,11 +2,14 @@ import os
 import sys
 import yaml
 import importlib
+import tempfile
 from snakemake.utils import makedirs
 from lcdblib.utils.imports import resolve_name
 from lcdblib.utils import utils
 from lcdblib.snakemake import aligners, helpers
 from lib import common
+
+tempfile.tempdir = common.tempdir_for_biowulf()
 
 shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
@@ -115,7 +118,9 @@ rule conversion_gffutils:
     run:
         import gffutils
         kwargs = conversion_kwargs[output[0]]
-        db = gffutils.create_db(data=input.gtf, dbfn=output.db, **kwargs)
+        fd, tmpdb = tempfile.mkstemp(suffix='.db', prefix='gffutils_')
+        db = gffutils.create_db(data=input.gtf, dbfn=tmpdb, **kwargs)
+        shell('mv {tmpdb} {output.db}')
 
 
 rule chromsizes:


### PR DESCRIPTION
sqlite3 is really slow on biowulf's shared filesystem; this ensures that if there's lscratch provided the gffutils db will be created there and then moved over.

Also adds human GENCODE v25 gfftutils db, which took about 40 mins to create from a 2.5M line GTF using the settings updated here.