### PR TITLE
add orig_filename to sampletables

### DIFF
--- a/chipseq.snakefile
+++ b/chipseq.snakefile
@@ -114,7 +114,7 @@ if 'orig_filename' in sampletable.columns:
         input: lambda wc: sampletable.set_index(sampletable.columns[0])['orig_filename'].to_dict()[wc.sample]
         output: patterns['fastq']
         run:
-            common.relative_symlink(input[0], output[0])
+            utils.make_relative_symlink(input[0], output[0])
 
     rule symlink_targets:
         input: targets['fastq']

--- a/ci/get-data.py
+++ b/ci/get-data.py
@@ -16,29 +16,14 @@ def _download_file(fn, dest=None):
     shell('wget -q -O- {url} > {dest}')
     return dest
 
-_download_file('rnaseq_samples/sample1/sample1.small_R1.fastq.gz')
-_download_file('rnaseq_samples/sample2/sample2.small_R1.fastq.gz')
-_download_file('rnaseq_samples/sample3/sample3.small_R1.fastq.gz')
-_download_file('rnaseq_samples/sample4/sample4.small_R1.fastq.gz')
-_download_file('chipseq_samples/input_1/input_1.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/ip_1/ip_1.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/input_2/input_2.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/ip_2/ip_2.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/ip_3/ip_3.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/ip_4/ip_4.tiny_R1.fastq.gz')
-_download_file('chipseq_samples/input_3/input_3.tiny_R1.fastq.gz')
-
-shell('mkdir -p data/rnaseq_samples/sample{{1,2,3,4}}')
-for n in [1, 2, 3, 4]:
-    shell(
-        'mv rnaseq_samples/sample{n}/sample{n}.small_R1.fastq.gz '
-        'data/rnaseq_samples/sample{n}/sample{n}_R1.fastq.gz'
-    )
-shell('rm -r rnaseq_samples')
-
-for s in ['ip_1', 'ip_2', 'ip_3', 'ip_4', 'input_1', 'input_2', 'input_3']:
-    shell('mkdir -p data/chipseq_samples/{s}')
-    shell(
-        'mv chipseq_samples/{s}/{s}.tiny_R1.fastq.gz '
-        'data/chipseq_samples/{s}/{s}_R1.fastq.gz'
-    )
+_download_file('rnaseq_samples/sample1/sample1.small_R1.fastq.gz', 'data/example_data/rnaseq_sample1.fq.gz')
+_download_file('rnaseq_samples/sample2/sample2.small_R1.fastq.gz', 'data/example_data/rnaseq_sample2.fq.gz')
+_download_file('rnaseq_samples/sample3/sample3.small_R1.fastq.gz', 'data/example_data/rnaseq_sample3.fq.gz')
+_download_file('rnaseq_samples/sample4/sample4.small_R1.fastq.gz', 'data/example_data/rnaseq_sample4.fq.gz')
+_download_file('chipseq_samples/input_1/input_1.tiny_R1.fastq.gz', 'data/example_data/chipseq_input1.fq.gz')
+_download_file('chipseq_samples/ip_1/ip_1.tiny_R1.fastq.gz', 'data/example_data/chipseq_ip1.fq.gz')
+_download_file('chipseq_samples/input_2/input_2.tiny_R1.fastq.gz', 'data/example_data/chipseq_input2.fq.gz')
+_download_file('chipseq_samples/ip_2/ip_2.tiny_R1.fastq.gz', 'data/example_data/chipseq_ip2.fq.gz')
+_download_file('chipseq_samples/ip_3/ip_3.tiny_R1.fastq.gz', 'data/example_data/chipseq_ip3.fq.gz')
+_download_file('chipseq_samples/ip_4/ip_4.tiny_R1.fastq.gz', 'data/example_data/chipseq_ip4.fq.gz')
+_download_file('chipseq_samples/input_3/input_3.tiny_R1.fastq.gz', 'data/example_data/chipseq_input3.fq.gz')

--- a/config/chipseq-sampletable.tsv
+++ b/config/chipseq-sampletable.tsv
@@ -1,11 +1,11 @@
 # Samplenames with the same "label" will be considered technical replicates
-samplename	antibody	biological_material	replicate	label
-input_1	input	wingdisc-1	1	input-wingdisc-1
-input_2	input	wingdisc-2	2	input-wingdisc-2
-ip_1	gaf	wingdisc-1	1	gaf-wingdisc-1
-ip_2	gaf	wingdisc-2	2	gaf-wingdisc-2
+samplename	antibody	biological_material	replicate	label	orig_filename
+input_1	input	wingdisc-1	1	input-wingdisc-1	data/example_data/chipseq_input1.fq.gz
+input_2	input	wingdisc-2	2	input-wingdisc-2	data/example_data/chipseq_input2.fq.gz
+ip_1	gaf	wingdisc-1	1	gaf-wingdisc-1	data/example_data/chipseq_ip1.fq.gz
+ip_2	gaf	wingdisc-2	2	gaf-wingdisc-2	data/example_data/chipseq_ip2.fq.gz
 
 # Note here we are treating ip_3 and ip_4 as technical replicates for the sake of testing
-ip_3	gaf	embryo-1	1	gaf-embryo-1
-ip_4	gaf	embryo-1	1	gaf-embryo-1
-input_3	input	embryo-1	1	input-embryo-1
+ip_3	gaf	embryo-1	1	gaf-embryo-1	data/example_data/chipseq_ip3.fq.gz
+ip_4	gaf	embryo-1	1	gaf-embryo-1	data/example_data/chipseq_ip4.fq.gz
+input_3	input	embryo-1	1	input-embryo-1	data/example_data/chipseq_input3.fq.gz

--- a/config/sampletable.tsv
+++ b/config/sampletable.tsv
@@ -1,5 +1,5 @@
-samplename	group
-sample1	control
-sample2	control
-sample3	treatment
-sample4	treatment
+samplename	group	orig_filename
+sample1	control	data/example_data/rnaseq_sample1.fq.gz
+sample2	control	data/example_data/rnaseq_sample2.fq.gz
+sample3	treatment	data/example_data/rnaseq_sample3.fq.gz
+sample4	treatment	data/example_data/rnaseq_sample4.fq.gz

--- a/rnaseq.snakefile
+++ b/rnaseq.snakefile
@@ -8,6 +8,16 @@ from lcdblib.utils import utils
 from lib import common
 
 # ----------------------------------------------------------------------------
+# Note:
+#
+# In order for automated tests to run, we need to make some settings that are
+# not optimal for practical usage. Search this file for the string 
+# "# TEST SETTINGS" to find those instances and to learn what changes you might
+# want to make.
+# ----------------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------------
 # SETUP
 # ----------------------------------------------------------------------------
 
@@ -132,6 +142,7 @@ if 'orig_filename' in sampletable.columns:
     rule symlink_targets:
         input: targets['fastq']
 
+
 rule cutadapt:
     """
     Run cutadapt
@@ -194,6 +205,7 @@ rule rRNA:
     threads: 6
     wrapper:
         wrapper_for('bowtie2/align')
+
 
 rule fastq_count:
     """
@@ -313,6 +325,7 @@ rule rrna_libsizes_table:
         with open(output.json, 'w') as fout:
             yaml.dump(y, fout, default_flow_style=False)
 
+
 rule libsizes_table:
     """
     Aggregate fastq and bam counts in to a single table
@@ -355,8 +368,6 @@ rule libsizes_table:
             yaml.dump(y, fout, default_flow_style=False)
 
 
-
-
 rule multiqc:
     """
     Aggregate various QC stats and logs into a single HTML report with MultiQC
@@ -397,7 +408,10 @@ rule markduplicates:
     log:
         patterns['markduplicates']['bam'] + '.log'
     params:
-        java_args='-Xmx32g'
+        # TEST SETTINGS:
+        # You may want to use something larger, like "-Xmx32g" for real-world
+        # usage.
+        java_args='-Xmx2g'
     wrapper:
         wrapper_for('picard/markduplicates')
 
@@ -413,8 +427,11 @@ rule collectrnaseqmetrics:
         metrics=patterns['collectrnaseqmetrics']['metrics'],
         pdf=patterns['collectrnaseqmetrics']['pdf']
     params:
-        extra="STRAND=NONE CHART_OUTPUT={}".format(patterns['collectrnaseqmetrics']['pdf']),
-        java_args='-Xmx32g'
+        # TEST SETTINGS:
+        # You may want to use something larger, like "-Xmx32g" for real-world
+        # usage.
+        java_args='-Xmx32g',
+        extra="STRAND=NONE CHART_OUTPUT={}".format(patterns['collectrnaseqmetrics']['pdf'])
     log: patterns['collectrnaseqmetrics']['metrics'] + '.log'
     wrapper: wrapper_for('picard/collectrnaseqmetrics')
 


### PR DESCRIPTION
It's currently undocumented (unless you read the snakefiles) that you can provide an `orig_filename` column to the sampletables and have them automatically symlinked over to sample directories. Super useful for mapping annoying core filenames over to something more meaningful. This PR modifies the example data download to use a different directory structure, and uses the `orig_filename` column in the sampletables to map the files in the new structure over to where they're expected. That way 1) the functionality is more discoverable and 2) it's actually tested now.
