### PR TITLE
Colocalization workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ workflows/rnaseq/downstream/rnaseq.html
 workflows/rnaseq/downstream/rnaseq_cache
 workflows/rnaseq/downstream/rnaseq_files
 workflows/rnaseq/downstream/*tsv
+workflows/chipseq/data
+workflows/rnaseq/data
+workflows/colocalization/results
+workflows/figures/figures
 docs/_build
 \.cache/v/cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - TYPE=references.snakefile
     - TYPE=figures.snakefile
     - TYPE=external.snakefile
+    - TYPE=colocalization.snakefile
     - TYPE=pytest
     - TYPE=docs
 

--- a/ci/travis-run.sh
+++ b/ci/travis-run.sh
@@ -45,6 +45,14 @@ case $TYPE in
     -j2 -T -k -p -r
     ;;
 
+  colocalization.snakefile)
+    cd workflows/colocalization \
+    && source activate lcdb-wf-test && \
+    snakemake \
+    --use-conda \
+    -j2 -T -k -p -r
+    ;;
+
   #pytest)
   #  source activate lcdb-wf-test && py.test wrappers/test -v
   #  ;;

--- a/workflows/chipseq/config/clusterconfig.yaml
+++ b/workflows/chipseq/config/clusterconfig.yaml
@@ -15,3 +15,6 @@ bigwig_neg:
 
 bigwig_pos:
   prefix: "--gres=lscratch:20 --mem=16g"
+
+macs2:
+  prefix: "--gres=lscratch:2- --mem=16g"

--- a/workflows/colocalization/Snakefile
+++ b/workflows/colocalization/Snakefile
@@ -1,0 +1,245 @@
+import sys
+sys.path.insert(0, srcdir('../..'))
+import os
+from textwrap import dedent
+import yaml
+import tempfile
+import pandas as pd
+from lcdblib.snakemake import helpers, aligners
+from lcdblib.utils import utils
+from lib import common
+from lib.patterns_targets import RNASeqConfig, ChIPSeqConfig
+import os
+from snakemake.utils import makedirs
+import pandas
+import yaml
+import numpy as np
+
+configfile: 'config/config.yaml'
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.executable('/bin/bash')
+
+chipseq_config = ChIPSeqConfig('config/config.yaml', 'config/chipseq_patterns.yaml', workdir='../chipseq')
+
+subworkflow chipseq:
+    configfile: chipseq_config.path
+    workdir: '../chipseq'
+
+subworkflow references:
+    configfile: chipseq_config.path
+    workdir: '../chipseq'
+
+chipseq_refdict, chipseq_args = common.references_dict(chipseq_config.config)
+
+# The rule to create the chromsizes file is in the references workflow; the
+# path to it can be determined from the config file (though it is awkwardly
+# nested)
+chromsizes = references(
+    chipseq_refdict[
+        chipseq_config.config['assembly']
+    ][
+        chipseq_config.config['aligner']['tag']
+    ]['chromsizes']
+)
+
+# Here we are adding all the called peaks to the bed files to check for
+# colocalization
+peaks = chipseq(utils.flatten(chipseq_config.targets['peaks']))
+for fn in peaks:
+    toks = fn.split('/')
+    peakcaller = toks[-3]
+    label = toks[-2]
+    key = peakcaller + '_' + label
+    config['beds'][key] = fn
+
+
+# Number of shufflings for GAT
+# TEST_SETTINGS: change this to something like 1000 or more
+N = 100
+
+targets = expand(
+    '{outdir}/{algorithm}/{domain}/{query}/{query}_vs_{reference}.txt',
+    outdir=config['output'],
+    domain=config['domains'].keys(),
+    query=config['beds'].keys(),
+    reference=config['beds'].keys(),
+    algorithm=['IntervalStats', 'GAT', 'jaccard', 'fisher'],
+)
+
+# Currently-supported options {algorithm: (possible values)}
+# IntervalStats: (f_05, f_01, f_001)
+# GAT: (l2fold, fractions)
+# jaccard: (jaccard)
+# fisher: (pval)
+pattern = '{outdir}/{algorithm}/{domain}/{value}_heatmap.pdf'
+targets += expand(pattern, outdir=config['output'], domain=config['domains'],
+                  algorithm='IntervalStats', value=['f_01'])
+targets += expand(pattern, outdir=config['output'], domain=config['domains'],
+                  algorithm='GAT', value=['l2fold', 'fractions'])
+targets += expand(pattern, outdir=config['output'], domain=config['domains'],
+                  algorithm='jaccard', value=['jaccard'])
+targets += expand(pattern, outdir=config['output'], domain=config['domains'],
+                  algorithm='fisher', value=['pval'])
+
+rule target:
+    input: targets
+
+
+rule chromsizes_bed:
+    input: chromsizes
+    output: os.path.join(config['output'], config['assembly'] + '.bed')
+    shell:
+        """awk '{{OFS="\\t"; print $1,"0",$2}}' {input} > {output}"""
+
+
+rule jaccard:
+    input:
+        domain=lambda wc: config['domains'][getattr(wc, 'domain')],
+        query=lambda wc: config['beds'][getattr(wc, 'query')],
+        reference=lambda wc: config['beds'][getattr(wc, 'reference')],
+        chromsizes=chromsizes
+    output: '{outdir}/jaccard/{domain}/{query}/{query}_vs_{reference}.txt'
+    shell:
+        """
+        bedtools intersect -a {input.query} -b {input.domain} | sort -k1,1 -k2n  > {output}.query.jaccard
+        bedtools intersect -a {input.reference} -b {input.domain} | sort -k1,1 -k2n  > {output}.reference.jaccard
+        bedtools jaccard -a {output}.query.jaccard -b {output}.reference.jaccard > {output}
+        rm {output}.query.jaccard {output}.reference.jaccard
+        """
+
+
+rule fisher:
+    input:
+        domain=lambda wc: config['domains'][getattr(wc, 'domain')],
+        query=lambda wc: config['beds'][getattr(wc, 'query')],
+        reference=lambda wc: config['beds'][getattr(wc, 'reference')],
+        chromsizes=chromsizes,
+    output: '{outdir}/fisher/{domain}/{query}/{query}_vs_{reference}.txt'
+    shell:
+        """
+        bedtools intersect -a {input.query} -b {input.domain} | sort -k1,1 -k2n > {output}.query.fisher
+        bedtools intersect -a {input.reference} -b {input.domain} | sort -k1,1 -k2n > {output}.reference.fisher
+        bedtools fisher -a {output}.query.fisher -b {output}.reference.fisher -g {input.chromsizes} > {output}
+        rm {output}.query.fisher {output}.reference.fisher
+        """
+
+
+rule intervalstats:
+    input:
+        domain=lambda wc: config['domains'][getattr(wc, 'domain')],
+        query=lambda wc: config['beds'][getattr(wc, 'query')],
+        reference=lambda wc: config['beds'][getattr(wc, 'reference')],
+    output: '{outdir}/IntervalStats/{domain}/{query}/{query}_vs_{reference}.txt'
+    run:
+        if input.query == input.reference:
+            run_self = '--self'
+        else:
+            run_self = ''
+        shell(
+            'IntervalStats '
+            '--query {input.query} '
+            '--reference {input.reference} '
+            '--output {output}.full '
+            '--domain {input.domain} '
+            '{run_self}'
+        )
+
+        # Summarize the output into a faster-to-parse file used by downstream
+        # analysis code.
+        #
+        # Output has columns:
+        #
+        # - n_{05,01,001}: number of significant associations at {0.05, 0.01,
+        #   0.001} respectively
+        #
+        # - f_{05,01,001}: fraction of total that are signficant
+        #
+        # - n: number of features
+        #
+        # - query, reference: labels
+        #
+        # - filename: "all" filename containing the details in case anything
+        #   needs re-calculation.
+        _df = pandas.read_table(
+            str(output[0]) + '.full',
+            names=['query', 'closest_ref', 'length', 'distance',
+                   'numerator', 'denominator', 'pval'])
+
+        n = float(len(_df))
+
+        def frac(x):
+            if n == 0:
+                return np.nan
+            return x / n
+
+        n_05 = sum(_df.pval < 0.05)
+        n_01 = sum(_df.pval < 0.01)
+        n_001 = sum(_df.pval < 0.001)
+        f_05 = frac(n_05)
+        f_01 = frac(n_01)
+        f_001 = frac(n_001)
+
+        df = pandas.DataFrame(
+            [
+                dict(
+                    query=wildcards.query,
+                    filename=str(output[0]) + '.full',
+                    reference=wildcards.reference,
+                    n=float(n),
+                    n_05=n_05,
+                    n_01=n_01,
+                    n_001=n_001,
+                    f_05=f_05,
+                    f_01=f_01,
+                    f_001=f_001,
+                )
+            ]
+        )
+        df.to_csv(str(output[0]), sep='\t', index=False)
+
+
+rule gat:
+    input:
+        domain=lambda wc: config['domains'][getattr(wc, 'domain')],
+        query=lambda wc: config['beds'][getattr(wc, 'query')],
+        reference=lambda wc: config['beds'][getattr(wc, 'reference')],
+    output: '{outdir}/GAT/{domain}/{query}/{query}_vs_{reference}.txt'
+    run:
+        shell('cut -f1,2,3 {input.query} > {output}.query.tmp')
+        shell('cut -f1,2,3 {input.reference} > {output}.reference.tmp')
+        if os.stat(output[0] + '.query.tmp').st_size == 0:
+            shell('touch {output}')
+        else:
+            shell(
+                'gat-run.py '
+                '--ignore-segment-tracks '
+                '--annotations {output}.reference.tmp '
+                '--segments {output}.query.tmp '
+                '--workspace {input.domain} '
+                '--counter nucleotide-overlap '
+                '--num-samples {N} '
+                '--output-counts-pattern {output}.%s.counts '
+                '--log {output}.log '
+                '--stdout {output} '
+            )
+        shell('rm {output}.query.tmp {output}.reference.tmp')
+
+
+rule heatmap:
+    input:
+        expand(
+            '{{outdir}}/{{algorithm}}/{{domain}}/{query}/{query}_vs_{reference}.txt',
+            query=list(config['beds'].keys()),
+            reference=list(config['beds'].keys())
+        )
+    output:
+        '{outdir}/{algorithm}/{domain}/{value}_heatmap.pdf'
+    shell:
+        'python scripts/colocalization_heatmap.py '
+        '--domain {wildcards.domain} '
+        '--algorithm {wildcards.algorithm} '
+        '--value {wildcards.value} '
+        '--outdir {config[output]} '
+        '--output {output}'
+
+# vim: ft=python

--- a/workflows/colocalization/Snakefile
+++ b/workflows/colocalization/Snakefile
@@ -29,6 +29,9 @@ subworkflow references:
     configfile: chipseq_config.path
     workdir: '../chipseq'
 
+subworkflow external:
+    workdir: '../external'
+
 chipseq_refdict, chipseq_args = common.references_dict(chipseq_config.config)
 
 # The rule to create the chromsizes file is in the references workflow; the
@@ -41,6 +44,12 @@ chromsizes = references(
         chipseq_config.config['aligner']['tag']
     ]['chromsizes']
 )
+
+# In the existing config file, we assume that all BED files are from the
+# `external` workflow.
+
+for k, v in config['beds'].items():
+    config['beds'][k] = external(v)
 
 # Here we are adding all the called peaks to the bed files to check for
 # colocalization

--- a/workflows/colocalization/Snakefile
+++ b/workflows/colocalization/Snakefile
@@ -94,8 +94,14 @@ rule target:
     input: targets
 
 
-rule chromsizes_bed:
+rule sorted_chromsizes:
     input: chromsizes
+    output: os.path.join(config['output'], config['assembly'] + '.sorted.chromsizes')
+    shell:
+        'sort -k1,1 {input} > {output}'
+
+rule chromsizes_bed:
+    input: rules.sorted_chromsizes.output
     output: os.path.join(config['output'], config['assembly'] + '.bed')
     shell:
         """awk '{{OFS="\\t"; print $1,"0",$2}}' {input} > {output}"""
@@ -106,13 +112,13 @@ rule jaccard:
         domain=lambda wc: config['domains'][getattr(wc, 'domain')],
         query=lambda wc: config['beds'][getattr(wc, 'query')],
         reference=lambda wc: config['beds'][getattr(wc, 'reference')],
-        chromsizes=chromsizes
+        chromsizes=rules.sorted_chromsizes.output
     output: '{outdir}/jaccard/{domain}/{query}/{query}_vs_{reference}.txt'
     shell:
         """
         bedtools intersect -a {input.query} -b {input.domain} | sort -k1,1 -k2n  > {output}.query.jaccard
         bedtools intersect -a {input.reference} -b {input.domain} | sort -k1,1 -k2n  > {output}.reference.jaccard
-        bedtools jaccard -a {output}.query.jaccard -b {output}.reference.jaccard > {output}
+        bedtools jaccard -a {output}.query.jaccard -b {output}.reference.jaccard -g {input.chromsizes} > {output}
         rm {output}.query.jaccard {output}.reference.jaccard
         """
 
@@ -122,7 +128,7 @@ rule fisher:
         domain=lambda wc: config['domains'][getattr(wc, 'domain')],
         query=lambda wc: config['beds'][getattr(wc, 'query')],
         reference=lambda wc: config['beds'][getattr(wc, 'reference')],
-        chromsizes=chromsizes,
+        chromsizes=rules.sorted_chromsizes.output
     output: '{outdir}/fisher/{domain}/{query}/{query}_vs_{reference}.txt'
     shell:
         """

--- a/workflows/colocalization/config/config.yaml
+++ b/workflows/colocalization/config/config.yaml
@@ -1,6 +1,7 @@
 beds:
-  GAF_pupa: ../external/data/modencode_gaf_pupa.bed
-  GAF_kc: ../external/data/modencode_gaf_kc.bed
+  # from the external workflow
+  GAF_pupa: data/modencode_gaf_pupa.bed
+  GAF_kc: data/modencode_gaf_kc.bed
 domains:
   dm6: results/dm6.bed
 output: results

--- a/workflows/colocalization/config/config.yaml
+++ b/workflows/colocalization/config/config.yaml
@@ -1,0 +1,7 @@
+beds:
+  GAF_pupa: ../external/data/modencode_gaf_pupa.bed
+  GAF_kc: ../external/data/modencode_gaf_kc.bed
+domains:
+  dm6: results/dm6.bed
+output: results
+assembly: dm6

--- a/workflows/colocalization/scripts/colocalization_heatmap.py
+++ b/workflows/colocalization/scripts/colocalization_heatmap.py
@@ -1,0 +1,256 @@
+import os
+import glob
+import pandas as pd
+import numpy as np
+import seaborn as sns
+from scipy.spatial import distance
+from scipy.cluster import hierarchy
+from matplotlib import pyplot as plt
+import argparse
+
+ap = argparse.ArgumentParser()
+ap.add_argument('--domain')
+ap.add_argument('--algorithm')
+ap.add_argument('--value')
+ap.add_argument('--outdir')
+ap.add_argument('--output')
+args = ap.parse_args()
+
+domain = args.domain
+algorithm = args.algorithm
+value = args.value
+
+
+def dataframe_for_domain(domain, algorithm):
+    """
+    Read all files within a directory and build the dataframe.
+
+    Empty files are listed as NaNs in the dataframe.
+    """
+    df = []
+    files = glob.glob(os.path.join(args.outdir, algorithm, domain, '*', '*.txt'))
+    for filename in files:
+        query, reference = os.path.basename(filename).replace('.txt', '').split('_vs_')
+        try:
+            _df = pd.read_table(filename, comment='#')
+        except pd.errors.EmptyDataError:
+            _df = pd.DataFrame([dict(value=np.nan)])
+
+        _df['query'] = query
+        _df['reference'] = reference
+        df.append(
+            _df.ix[0].to_dict()
+        )
+    return pd.DataFrame(df)
+
+
+# Cluster methods
+METRIC = 'correlation'
+METHOD = 'average'
+
+
+def dataframe_for_value(domain, algorithm, value):
+
+    df = dataframe_for_domain(domain, algorithm)
+
+    vmin, vmax = None, None
+
+    # For IntervalStats, Use the "fraction of intervals with p<0.01" as the
+    # value.
+    #
+    # These are all positive values. NaNs are set to 0, and the diagonal is
+    # set to 1.0 (i.e., 100% of intervals are significant with respect to
+    # each other)
+    if algorithm == 'IntervalStats':
+        piv = df.pivot(index='query', columns='reference', values=value)
+        fill_piv = piv.fillna(0)
+        vmax = fill_piv.max().max()
+        np.fill_diagonal(fill_piv.values, 1)
+        units = 'fraction pvals < 0.%s' % (value.split('_')[-1])
+        title = 'IntervalStats'
+
+    # For GAT log2foldchange, set anything with qval > 0.05 to
+    # logfoldchange = 0. Diagonal is filled with 0 (log2foldchange of 1).
+    # NaNs are also set to 0.
+    elif algorithm == 'GAT' and value == 'l2fold':
+        piv = df.pivot(index='query', columns='reference', values='l2fold')
+
+        # used for checking
+        mask = df.pivot(index='query', columns='reference',
+                        values='qvalue')
+        title = 'GAT foldchange'
+        piv[mask > 0.05] = 0
+        piv = piv.fillna(0)
+        fill_piv = piv
+        np.fill_diagonal(fill_piv.values, 0)
+        units = 'log2fold'
+
+    # For GAT fractions, we set the upper and lower triangles of the matrix
+    # to the "track" and "annotation" overlaps in GAT terminology. We also
+    # get a significance value here (qval) so we set the fraction overlap
+    # to zero for anything with qval > 0.05.
+    elif algorithm == 'GAT' and value == 'fractions':
+        segment_frac = df.pivot(index='query', columns='reference',
+                                values='percent_overlap_size_track')
+        annotation_frac = df.pivot(index='query', columns='reference',
+                                   values='percent_overlap_size_annotation')
+        mask = df.pivot(index='query', columns='reference', values='qvalue')
+        piv = segment_frac
+        lower_tri_mask = np.ones(piv.shape, dtype='bool')
+        lower_tri_mask[np.tril_indices(len(piv))] = False
+        piv[lower_tri_mask] = annotation_frac[lower_tri_mask]
+        piv[mask > 0.05] = 0
+        fill = 0
+        fill_piv = piv
+        units = 'percentage overlap'
+        title = 'GAT percentage nucleotide overlap'
+
+    # For fisher, we want to plot the -log10(two-tail pval).
+    #
+    # So we keep track of the ratio, flip pvals where ratio <1, and replace
+    # inf and -inf with the otherwise max and min values respectively. NaNs
+    # are given a -log10(pval) = 0 (so a pval of 1.0).
+    elif algorithm == 'fisher' and value == 'pval':
+        piv = df.pivot(index='query', columns='reference',
+                       values='two-tail')
+        mask_left = df.pivot(index='query', columns='reference',
+                             values='left')
+        mask_right = df.pivot(index='query', columns='reference',
+                              values='right')
+        mask_ratio = df.pivot(index='query', columns='reference',
+                              values='ratio')
+        flip = mask_ratio < 1
+        piv = -np.log10(piv)
+        piv[flip] *= -1
+        mx = piv.replace([np.inf], 0).max().max()
+        mn = piv.replace([-np.inf], 0).min().min()
+        piv = piv.replace([np.inf], mx)
+        piv = piv.replace([-np.inf], mn)
+        fill_piv = piv.fillna(0)
+        units = '-log10(pval)'
+        title = 'Fisher'
+
+    ####################################################
+    # TODO: also plot fisher ratio
+    ####################################################
+
+    # For jaccard, we plot the value directly. While the value can range
+    # [0, 1], in practice we rarely find such good overlap.
+    elif algorithm == 'jaccard' and value == 'jaccard':
+        piv = df.pivot(index='query', columns='reference', values='jaccard')
+        fill_piv = piv
+        units = 'Jaccard statistic'
+        vmin, vmax = (0, .3)
+        title = 'Jaccard'
+
+    return dict(
+      fill_piv=fill_piv,
+      vmin=vmin,
+      vmax=vmax,
+      units=units,
+      title=title
+    )
+
+
+def plot_heatmap(fill_piv, vmin, vmax, title, units, metric='euclidean',
+                 method='average', idx=None, clustermap_kwargs=dict()):
+    """
+    Plot a clustered heatmap of the provided values. Rows are clustered
+    identically as columns so that the diagonal represents the self-self
+    comparisons.
+
+    Parameters
+    ----------
+
+    fill_piv : pandas.DataFrame
+        A prepared dataframe where rownames == colnames and where -inf, inf,
+        and NaN have been filled in with finite values.
+
+    vmin, vmax : float
+        Colormap limits. NOT CURRENTLY USED.
+
+    title : str
+        Title for plot
+
+    units : str
+        Units to use in colorbar
+
+    metric : str
+        Clustering metric. See `scipy.distance` for available options.
+
+    method : clustering method
+        Hierarchical clustering linkage method. See `scipy.hierarchy` for
+        available options.
+
+    idx : None or index
+        If not None, then this index is used to subset `fill_piv`.
+
+    clustermap_kwargs : dict
+        Additional arguments passed to seaborn.clustermap.
+    """
+
+
+    fill_piv = fill_piv.astype(float)
+    # subset if requested
+    if idx is not None:
+        fill_piv = fill_piv.ix[idx, idx]
+
+    # Distance matrix, setting NaN to zero if necessary
+    dist = distance.pdist(fill_piv.values, metric=metric)
+    dist[np.isnan(dist)] = 0
+    dist[dist < 0] = 0
+
+    # ward actually uses values directly rather than using the distance matrix.
+    if method == 'ward':
+        vals = fill_piv.values
+    else:
+        vals = dist
+
+    # Here we compute the row linkage and provide that to sns.clustermap as
+    # both row and column linkages so that the same clustering is used. This
+    # gets us the self-self colocalization on the diagonal.
+    row_linkage = hierarchy.linkage(vals, method=method)
+
+    # catch and fix errors in dendrogram before sending to clustermap
+    mx = row_linkage[np.isfinite(row_linkage)].max()
+    mn = row_linkage[np.isfinite(row_linkage)].min()
+    # row_linkage[np.isinf(row_linkage)] = mx
+    # scipy.clip(row_linkage, 0, mx, row_linkage)
+    ind = hierarchy.dendrogram(row_linkage, no_plot=True)['leaves']
+
+
+    a = sns.clustermap(fill_piv, row_linkage=row_linkage,
+                       col_linkage=row_linkage, **clustermap_kwargs)
+
+    # Fix labels
+    for txt in a.ax_heatmap.get_xticklabels():
+        txt.set_rotation(90)
+    for txt in a.ax_heatmap.get_yticklabels():
+        txt.set_rotation(0)
+
+    # Use the provided units to label the colorbar
+    a.cax.set_ylabel(units)
+
+    # Add figure-level title and tweak margins.
+    fig = plt.gcf()
+    fig.suptitle(title, weight='bold', size=20)
+    fig.subplots_adjust(right=0.8, bottom=0.2)
+    return a
+
+
+
+v = dataframe_for_value(domain, algorithm, value)
+
+fig = plot_heatmap(
+  fill_piv=v['fill_piv'],
+  vmin=v['vmin'],
+  vmax=v['vmax'],
+  title=v['title'],
+  units=v['units'],
+  metric='euclidean',
+  method='average',
+  idx=None,
+  clustermap_kwargs=dict()
+)
+
+fig.savefig(args.output)

--- a/workflows/colocalization/scripts/colocalization_heatmap.py
+++ b/workflows/colocalization/scripts/colocalization_heatmap.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('agg')
 import os
 import glob
 import pandas as pd

--- a/workflows/external/Snakefile
+++ b/workflows/external/Snakefile
@@ -14,7 +14,8 @@ modencode = {
 
 
 rule targets:
-    input: list(modencode.keys())
+    input:
+        list(modencode.keys()),
 
 
 rule download_chainfile:
@@ -33,9 +34,11 @@ rule modencode:
 
         def generator():
             """
-            modENCODE "GFF" files sometimes have negative coordinates and do
-            not have 'chr' chromosome prefixes. Fix those here, and output
-            a BED line rather than GFF.
+            modENCODE "GFF" files sometimes have negative coordinates.  Fix
+            those here, and output a BED line rather than GFF.
+
+            Also, since we're about to liftover, we need to prefix chrom names
+            with "chr".
             """
             for line in open(output[0] + '.tmp'):
                 if line.startswith('#'):
@@ -55,12 +58,18 @@ rule modencode:
         shell('rm {output}.tmp')
 
 
+
+# Note that since the original reference used for the example does not have
+# "chr" chromosome prefixes, we remove them here immediately after lifting
+# over.
 rule liftover:
     input:
         bed='{prefix}.dm3',
         chainfile=rules.download_chainfile.output
     output: '{prefix}'
     shell:
-        'liftOver {input.bed} {input.chainfile} {output} {output}.unmapped'
+        'liftOver {input.bed} {input.chainfile} {output}.chr {output}.unmapped'
+        '&& sed "s/^chr//g" {output}.chr > {output} '
+        '&& rm {output}.chr'
 
 # vim: ft=python


### PR DESCRIPTION
This PR adds a colocalization workflow, which runs IntervalStats, jaccard, fisher, and GAT on a bunch of bed files and then plots heatmaps of pairwise colocalization. While I've had this workflow kicking around for a while, it was never integrated well into any chipseq workflows and always required hand-editing the config file.

Now, using the updated system of subworkflows and separate patterns/targets files, it's possible to configure a new chipseq run in `workflows/chipseq/config/config.yaml` . . . and then with _no other changes_, run the colocalization workflow and it will run the peak-calling for the new run in the chipseq workflow, then run all the newly necessary pairwise comparisons, and finally propagate all the way out to a new row and column in the colocalization heatmaps.

It's also integrated with the new external workflow, so adding other published data and having it propagate to the heatmaps is trivial.


