### PR TITLE
Add multiqc patterns

### DIFF
--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -7,3 +7,12 @@ fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+sp:
+  fastq_screen:
+    fn: '*.screen.txt'
+  picard/rnaseqmetrics:
+    contents_re: '.*picard\.analysis\.[Rr]na[Ss]eq[Mm]etrics.*'
+    shared: true
+  picard/markdups:
+    contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
+    shared: true

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -13,3 +13,6 @@ sp:
   picard/rnaseqmetrics:
     contents_re: '.*picard\.analysis\.[Rr]na[Ss]eq[Mm]etrics.*'
     shared: true
+  picard/markdups:
+    contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
+    shared: true

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -10,3 +10,6 @@ fn_clean_exts:
 sp:
   fastq_screen:
     fn: '*.screen.txt'
+  picard/rnaseqmetrics:
+    contents_re: '.*picard\.analysis\.[Rr]na[Ss]eq[Mm]etrics.*'
+    shared: true

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -7,3 +7,6 @@ fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+sp:
+  fastq_screen:
+    fn: '*.screen.txt'


### PR DESCRIPTION
- Fixes pulling in fastq_screen and picard/RNASeqMetrics multiqc.
- Starts to try to address the same issue with picard/markdups, but it still is not working.

For markdups I have tried adding:
- `fn: `
- `contents: `
- `contents_re:`

But none of these are working.