### PR TITLE
Multiqc tweaking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ salmon
 samtools
 snakemake
 subread
+trackhub
 ucsc-fetchchromsizes
 ucsc-gtftogenepred
 ucsc-liftover

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -382,7 +382,8 @@ rule fingerprint:
         # TEST SETTINGS: You'll probably want to change --numberOfSamples to
         # something higher (default is 500k) when running on real data
         '--numberOfSamples 5000 '
-        '&> {log}'
+        '&> {log} '
+        '&& sed -i "s/NA/0.0/g" {output.metrics} '
 
 
 rule macs2:

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -253,7 +253,7 @@ rule multiqc:
     output:
         c.targets['multiqc']
     params:
-        analysis_directory=" ".join([c.sample_dir, c.agg_dir]),
+        analysis_directory=" ".join([c.sample_dir, c.agg_dir, c.peak_calling]),
         extra='--config config/multiqc_config.yaml',
         outdir=os.path.dirname(c.targets['multiqc'][0]),
         basename=os.path.basename(c.targets['multiqc'][0])
@@ -268,6 +268,7 @@ rule multiqc:
         '--filename {params.basename} '
         '--config config/multiqc_config.yaml '
         '{params.analysis_directory} '
+
         '&> {log} '
 
 

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -207,6 +207,18 @@ rule libsizes_table:
         df['stage'] = df.filename.apply(stage)
         df = df.set_index('filename')
         df = df.pivot('sample', columns='stage', values='million')
+
+        # make nicer column names
+        convert = {
+            'fastq.libsize': 'stage1_raw',
+            'cutadapt.fastq.libsize' : 'stage2_trimmed',
+            'cutadapt.bam.libsize': 'stage3_aligned',
+            'cutadapt.unique.bam.libsize': 'stage4_unique',
+            'cutadapt.unique.nodups.bam.libsize': 'stage5_nodups',
+        }
+
+        df.columns = [convert[i] for i in df.columns]
+
         df.to_csv(output.tsv, sep='\t')
         y = {
             'id': 'libsizes_table',

--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -1,5 +1,11 @@
-fn_clean_exts:
-  #- '.cutadapt'
+# Anything to the right of these extensions is removed when generating sample
+# names.  Note that removing .cutadapt (and therefore effectively merging
+# .cutadapt.bam with .cutadapt.fastq.gz and .fastq.gz) is OK because below
+# we're running FastQC on them separately
+#
+# See http://multiqc.info/docs/#sample-name-cleaning
+extra_fn_clean_exts:
+  - '.cutadapt'
   - ']'
   - '.log'
   - '.bam.bowtie2'
@@ -7,6 +13,12 @@ fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+
+
+# Modify the module search patterns to match what we're creating in the
+# workflow.
+#
+# See http://multiqc.info/docs/#module-search-patterns
 sp:
   fastq_screen:
     fn: '*.screen.txt'
@@ -16,3 +28,52 @@ sp:
   picard/markdups:
     contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
     shared: true
+
+# Set the module order to reflect the order of the workflow. Note that here
+# we're also running the FastQC module multiple times, and putting them in
+# their logical locations within the order of the workflow.
+#
+# Note that any modules not found on this list float
+# to the top, so if you add more to the workflow, might want to add them in the
+# right place here.
+#
+# See http://multiqc.info/docs/#order-of-modules
+module_order:
+    - fastqc:
+        name: 'FastQC (raw)'
+        path_filters:
+            - '*.fastq.gz_fastqc.zip'
+    - libsizes_table
+    - cutadapt
+    - fastqc:
+        name: 'FastQC (trimmed)'
+        target: ''
+        path_filters:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
+    - fastq_screen
+    - bowtie2
+    - fastqc:
+        name: 'FastQC (aligned, unique, nodups)'
+        target: ''
+        path_filters:
+            - '*.cutadapt.unique.nodups.bam_fastqc.zip'
+    - deeptools
+
+# This organizes the FastQC general sample table columns so that the different
+# stages are right next to each other, making it easier to compare the effects
+# of the different stages on the stats.
+#
+# See http://multiqc.info/docs/#customising-tables
+table_columns_placement:
+  FastQC (raw):
+    total_sequences: 20
+    percent_duplicates: 30
+    percent_gc: 40
+  FastQC (trimmed):
+    total_sequences: 21
+    percent_duplicates: 31
+    percent_gc: 41
+  FastQC (aligned, unique, nodups):
+    total_sequences: 22
+    percent_duplicates: 32
+    percent_gc: 42

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -285,6 +285,16 @@ rule libsizes_table:
         df['stage'] = df.filename.apply(stage)
         df = df.set_index('filename')
         df = df.pivot('sample', columns='stage', values='million')
+
+        # make nicer column names
+        convert = {
+            'fastq.libsize': 'stage1_raw',
+            'cutadapt.fastq.libsize' : 'stage2_trimmed',
+            'cutadapt.bam.libsize': 'stage3_aligned',
+        }
+
+        df.columns = [convert[i] for i in df.columns]
+
         df.to_csv(output.tsv, sep='\t')
         y = {
             'id': 'libsizes_table',

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -1,5 +1,11 @@
-fn_clean_exts:
-  #- '.cutadapt'
+# Anything to the right of these extensions is removed when generating sample
+# names.  Note that removing .cutadapt (and therefore effectively merging
+# .cutadapt.bam with .cutadapt.fastq.gz and .fastq.gz) is OK because below
+# we're running FastQC on them separately
+#
+# See http://multiqc.info/docs/#sample-name-cleaning
+extra_fn_clean_exts:
+  - '.cutadapt'
   - ']'
   - '.log'
   - '.bam.bowtie2'
@@ -7,6 +13,12 @@ fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+
+
+# Modify the module search patterns to match what we're creating in the
+# workflow.
+#
+# See http://multiqc.info/docs/#module-search-patterns
 sp:
   fastq_screen:
     fn: '*.screen.txt'
@@ -16,3 +28,66 @@ sp:
   picard/markdups:
     contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
     shared: true
+
+
+# Ignore the rRNA files, which were just cluttering the tables. We're
+# independently calculating the rRNA libsizes anyway, so there's no need for
+# them to be included.
+#
+# See http://multiqc.info/docs/#ignoring-files
+fn_ignore_files:
+  - '*rrna.bam*'
+
+
+# Set the module order to reflect the order of the workflow. Note that here
+# we're also running the FastQC module multiple times, and putting them in
+# their logical locations within the order of the workflow.
+#
+# Note that any modules not found on this list float
+# to the top, so if you add more to the workflow, might want to add them in the
+# right place here.
+#
+# See http://multiqc.info/docs/#order-of-modules
+module_order:
+    - fastqc:
+        name: 'FastQC (raw)'
+        path_filters:
+            - '*.fastq.gz_fastqc.zip'
+    - libsizes_table
+    - rrna_percentages_table
+    - cutadapt
+    - fastqc:
+        name: 'FastQC (trimmed)'
+        target: ''
+        path_filters:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
+    - fastq_screen
+    - bowtie2
+    - fastqc:
+        name: 'FastQC (aligned)'
+        target: ''
+        path_filters:
+            - '*.cutadapt.bam_fastqc.zip'
+    - picard
+    - rseqc
+    - salmon
+    - featureCounts
+
+# This organizes the FastQC general sample table columns so that the different
+# stages are right next to each other, making it easier to compare the effects
+# of the different stages on the stats.
+#
+# See http://multiqc.info/docs/#customising-tables
+table_columns_placement:
+  FastQC (raw):
+    total_sequences: 20
+    percent_duplicates: 30
+    percent_gc: 40
+  FastQC (trimmed):
+    total_sequences: 21
+    percent_duplicates: 31
+    percent_gc: 41
+  FastQC (aligned):
+    total_sequences: 22
+    percent_duplicates: 32
+    percent_gc: 42


### PR DESCRIPTION
This PR overhauls the MultiQC config for both RNA-seq and ChIP-seq:

- general stats table is now much less confusing, as rows for different stages (raw, cutadapt, bam) are effectively merged into columns
- running fastqc module separate times (raw, trimmed, aligned) gives different sections and also gives the corresponding columns in the general stats table
- ordering of modules reflects the workflow
- general stats columns are organized so that the different stages of fastqc can be directly compared to each other
- better column names and better ordering for the libsizes table
- plotFingergprint logs will now make it into the multiqc report