### PR TITLE
some minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ workflows/rnaseq/downstream/*tsv
 workflows/chipseq/data
 workflows/rnaseq/data
 workflows/colocalization/results
+logs
+slurm*out
 workflows/figures/figures
 docs/_build
 \.cache/v/cache/

--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -110,7 +110,9 @@ def merged_input_for_ip(sampletable, merged_ip):
     ]
 
     if input_label.nunique() != 1:
-        print("Expected a single input label, found: {0}".format(input_label))
+        raise ValueError(
+            "Expected a single input label for biological_material='{1}', "
+            "found {0}. ".format(input_label.tolist(), biomaterial))
 
     return input_label.values[0]
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -467,4 +467,21 @@ def get_techreps(sampletable, label):
     """
     # since we're not requiring a name but we want to use `loc`
     first_col = sampletable.columns[0]
-    return list(sampletable.loc[sampletable['label'] == label, first_col])
+    result = list(sampletable.loc[sampletable['label'] == label, first_col])
+
+    # If we're using a ChIP-seq-like sampletable we can provide a more
+    # informative error message.
+
+    is_chipseq = 'antibody' in sampletable.columns
+    if is_chipseq:
+        err = ("No technical replicates found for label '{}'. This looks to "
+               "be a ChIP-seq experiment; check the peak-calling section of"
+               "the config.".format(label)
+              )
+    else:
+        err = "No technical replicates found for label '{}'.".format(label)
+
+    if len(result) == 0:
+        raise ValueError(err)
+
+    return result

--- a/lib/rnaseq_trackhub.py
+++ b/lib/rnaseq_trackhub.py
@@ -13,7 +13,7 @@ import os
 import pandas
 import yaml
 import matplotlib
-from trackhub.helpers import sanitize
+from trackhub.helpers import sanitize, hex2rgb, dimensions_from_subgroups, filter_composite_from_subgroups
 from trackhub import CompositeTrack, ViewTrack, SubGroupDefinition, Track, default_hub
 from trackhub.upload import upload_hub
 
@@ -64,26 +64,6 @@ subgroups.append(
         mapping={'pos': 'pos', 'neg': 'neg'}))
 
 
-def dimensions_from_subgroups(s):
-    """
-    Given a sorted list of subgroups, return a string appropriate to provide as
-    a composite track's `dimensions` arg
-    """
-    letters = 'XYABCDEFGHIJKLMNOPQRSTUVWZ'
-    return ' '.join(['dim{0}={1}'.format(dim, sg.name) for dim, sg in zip(letters, s)])
-
-
-def filter_composite_from_subgroups(s):
-    """
-    Given a sorted list of subgroups, return a string appropriate to provide as
-    the a composite track's `filterComposite` argumen argumen
-    """
-    dims = []
-    for letter, sg in zip('ABCDEFGHIJKLMNOPQRSTUVWZ', s[2:]):
-        dims.append('dim{0}'.format(letter))
-    if dims:
-        return ' '.join(dims)
-
 # Identify the sort order based on the config, and create a string appropriate
 # for use as the `sortOrder` argument of a composite track.
 to_sort = hub_config['subgroups'].get('sort_order', [])
@@ -116,14 +96,6 @@ supplemental_view = ViewTrack(
     tracktype='bigBed', short_label='Supplemental', long_label='Supplemental')
 
 colors = hub_config.get('colors', [])
-
-
-def hex2rgb(h):
-    """
-    Given a hex color code, return a 0-255 RGB tuple as a CSV string, e.g.,
-    "#ff0000" -> "255,0,0"
-    """
-    return ','.join(map(lambda x: str(int(x * 255)), matplotlib.colors.hex2color(h)))
 
 
 def decide_color(samplename):

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -23,7 +23,6 @@ include: '../references/Snakefile'
 shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
-
 c = ChIPSeqConfig(config, 'config/chipseq_patterns.yaml')
 
 
@@ -247,6 +246,8 @@ rule multiqc:
             utils.flatten(c.targets['cutadapt']) +
             utils.flatten(c.targets['bam']) +
             utils.flatten(c.targets['markduplicates']) +
+            utils.flatten(c.targets['fingerprint']) +
+            utils.flatten(c.targets['peaks']) +
             utils.flatten(c.targets['fastq_screen'])
         ),
         config='config/multiqc_config.yaml'
@@ -268,7 +269,6 @@ rule multiqc:
         '--filename {params.basename} '
         '--config config/multiqc_config.yaml '
         '{params.analysis_directory} '
-
         '&> {log} '
 
 


### PR DESCRIPTION
This PR is a round of updates discovered while working on other RNA-seq and ChIP-seq projects:

- more informative error when chipseq is misconfigured
- added some .gitignore patterns for files created after running on slurm
- rnaseq_trackhub.py cleaned up so it uses functions now included in the latest version of trackhub
- chipseq multiqc now depends on peaks and fingerprint (since latest multiqc has modules to find these)
