### PR TITLE
Figures workflow overhaul

### DIFF
--- a/workflows/colocalization/scripts/colocalization_heatmap.py
+++ b/workflows/colocalization/scripts/colocalization_heatmap.py
@@ -240,8 +240,15 @@ def plot_heatmap(fill_piv, vmin, vmax, title, units, metric='euclidean',
     return a
 
 
-
 v = dataframe_for_value(domain, algorithm, value)
+
+if (v['fill_piv'] < 0).values.any() & (v['fill_piv'] > 0).values.any():
+    center = 0
+    cmap = sns.color_palette('RdBu_r', as_cmap=True)
+else:
+    center = None
+    cmap = sns.cubehelix_palette(as_cmap=True)
+
 
 fig = plot_heatmap(
   fill_piv=v['fill_piv'],
@@ -252,7 +259,7 @@ fig = plot_heatmap(
   metric='euclidean',
   method='average',
   idx=None,
-  clustermap_kwargs=dict()
+  clustermap_kwargs=dict(center=center, cmap=cmap)
 )
 
 fig.savefig(args.output)

--- a/workflows/figures/Snakefile
+++ b/workflows/figures/Snakefile
@@ -1,3 +1,23 @@
+"""
+This workflow is used to drive downstream analysis scripts.
+
+Scripts live in the `scripts` subdirectory. For each script `scriptname.py`,
+the script is expected to create a README.txt file in ReStructured Text format
+in the `figures/scriptname/README.txt`. Of course it will likely do all sorts
+of other things, but this is the only output fil that is expected. It's best to
+write this file at the very end of the script so that it only is created after
+everything else successfully completes.
+
+Use the rule's inputs to set dependencies. The examples below show how to get
+these dependencies from the other workflows.
+
+Re-run rules where the script changeed with::
+
+    snakemake -R `snakemake --list-code-changes`
+
+"""
+
+
 import sys
 sys.path.insert(0, srcdir('../..'))
 import os
@@ -10,6 +30,7 @@ chipseq_config = ChIPSeqConfig('config/config.yaml', 'config/chipseq_patterns.ya
 
 rnaseq_refdict, rnaseq_args = common.references_dict(rnaseq_config.config)
 
+
 subworkflow rnaseq:
     configfile: rnaseq_config.path
     workdir: '../rnaseq'
@@ -20,27 +41,42 @@ subworkflow chipseq:
     workdir: '../chipseq'
 
 
+# "Register" the various scripts here. Their expected READMEs will be added to
+# the `all` rule. Each script's rule still needs to be created though, along
+# with whatever upstream dependencies it might have.
+SCRIPTS = [
+    'scripts/peak_count.py',
+    'scripts/peaks_at_promoters.py',
+]
+
+
+def readme_for(scriptname):
+    scriptname = os.path.basename(scriptname)
+    return os.path.join('figures', scriptname.replace('.py', ''), 'README.txt')
+
+
+READMES = [readme_for(i) for i in SCRIPTS]
+READMES += [
+    'figures/rnaseq/README.txt',
+    'figures/chipseq/README.txt',
+]
+
 rule all:
     input:
-        'figures/peak_count/peak_count.tsv',
-        'figures/peaks_at_promoters/summary.txt'
+        READMES,
+        'guide.html',
+        [os.path.join('figures/rnaseq', os.path.basename(i)) for i in utils.flatten(rnaseq_config.targets['downstream'])]
 
 
 rule peak_count:
     # This rule depends on *all* the peaks called by the chipseq workflow,
     # which we can get by accessing the targets of that workflow, like this:
-    input: chipseq(utils.flatten(chipseq_config.targets['peaks']))
-    output: 'figures/peak_count/peak_count.tsv'
-    run:
-        import pandas as pd
-        import pybedtools
-        df = []
-        for i in input:
-            toks = i.split('/')
-            peakcaller = toks[-3]
-            label = toks[-2]
-            df.append(dict(peakcaller=peakcaller, label=label, count=len(pybedtools.BedTool(i))))
-        pd.DataFrame(df)[['peakcaller', 'label', 'count']].to_csv(output[0], sep='\t', index=False)
+    input:
+        chipseq(utils.flatten(chipseq_config.targets['peaks']))
+    output:
+        readme_for('peak_count.py')
+    script:
+        'scripts/peak_count.py'
 
 
 rule peaks_at_promoters:
@@ -54,8 +90,120 @@ rule peaks_at_promoters:
         db=rnaseq(rnaseq_refdict['dmel']['test']['gtf'] + '.db'),
         peaks=chipseq(utils.flatten(chipseq_config.targets['peaks']))
     output:
-        'figures/peaks_at_promoters/summary.txt'
+        readme_for('peaks_at_promoters.py')
     script:
         'scripts/peaks_at_promoters.py'
+
+
+rule rnaseq_dag:
+    """
+    Plots the DAG of the RNA-seq workflow.
+    """
+    input: '../rnaseq/Snakefile'
+    output: 'rnaseq_dag.png'
+    shell:
+        'snakemake --nolock -nprs {input} -d $(dirname {input}) --rulegraph | dot -Tpng > {output}'
+
+
+rule chipseq_dag:
+    """
+    Plots the DAG of the ChIP-seq workflow.
+    """
+    input: '../chipseq/Snakefile'
+    output: 'chipseq_dag.png'
+    shell:
+        'snakemake --nolock -nprs {input} -d $(dirname {input}) --rulegraph | dot -Tpng > {output}'
+
+
+rule figures_dag:
+    """
+    Plots the DAG of the figures workflow.
+    """
+    input: 'Snakefile'
+    output: 'figures_dag.png'
+    shell:
+        'snakemake --nolock -nprs {input} -d $(dirname {input}) --rulegraph | dot -Tpng > {output}'
+
+
+rule report:
+    """
+    Gathers together all the READMEs, as well as an "updates.rst" file and any
+    DAGs to create, and builds an HTML report tying everything together.
+    """
+    input:
+        readmes=READMES,
+        updates='updates.rst',
+        rnaseq_dag=rules.rnaseq_dag.output,
+        chipseq_dag=rules.chipseq_dag.output,
+        figures_dag=rules.figures_dag.output,
+
+    output: 'guide.html'
+    run:
+        s = []
+        s.append(open('updates.rst').read())
+        for r in sorted(input.readmes):
+
+            # add titles named after the figure directory
+            name = os.path.basename(os.path.dirname(r))
+            s.append('``' + name + '``')
+            s.append('=' * (len(name) + 4))
+            d = os.path.dirname(r)
+
+            # Add a link to that figure directory, so that when viewing in
+            # a browser you can view the file contents.
+            s.append('`{name} analysis directory <{d}>`_'.format(**locals()))
+            s.append(open(r).read())
+            s.append('')
+
+        with open('guide.rst', 'w') as fout:
+            fout.write('\n'.join(s))
+
+        shell('rst2html.py --stylesheet style.css guide.rst > guide.html && rm guide.rst')
+
+
+rule rnaseq_symlinks:
+    """
+    Symlinks just the results from the RNA-seq analysis into a figures
+    subdirectory, so that it gets picked up by the report and packaging.
+    """
+    input:
+        [
+            rnaseq(i) for i in utils.flatten(rnaseq_config.targets['downstream'])
+            + utils.flatten(rnaseq_config.targets['multiqc'])
+        ]
+    output:
+        [os.path.join('figures/rnaseq', os.path.basename(i)) for i in utils.flatten(rnaseq_config.targets['downstream'])],
+        'figures/rnaseq/README.txt',
+    run:
+        for i in input:
+            utils.make_relative_symlink(i, os.path.join('figures/rnaseq', os.path.basename(i)))
+        with open('figures/rnaseq/README.txt', 'w') as fout:
+            fout.write(dedent(
+                """
+                RNA-seq analysis -- see ``rnaseq.html`` and ``multiqc.html`` for details.
+                """))
+
+rule chipseq_symlinks:
+    """
+    Symlinks just the results from the ChIP-seq analysis into a figures
+    subdirectory, so that it gets picked up by the report and packaging.
+    """
+    input:
+        [chipseq(i) for i in utils.flatten(chipseq_config.targets['fingerprint']) + chipseq_config.targets['multiqc']]
+    output:
+        'figures/chipseq/README.txt',
+    run:
+        for i in input:
+            utils.make_relative_symlink(i, os.path.join('figures/chipseq', os.path.basename(i)))
+        with open(output[0], 'w') as fout:
+            fout.write(dedent(
+                """
+                ChIP-seq analysis -- see ``multiqc.html`` for details on QC,
+
+                The "fingerprint" PNGs show the IP vs input fingerprint plots.
+                See `plotFingerprint docs
+                <http://deeptools.readthedocs.io/en/latest/content/tools/plotFingerprint.html>`_
+                for details.
+                """))
 
 # vim: ft=python

--- a/workflows/figures/Snakefile
+++ b/workflows/figures/Snakefile
@@ -56,10 +56,14 @@ def readme_for(scriptname):
 
 
 READMES = [readme_for(i) for i in SCRIPTS]
-READMES += [
-    'figures/rnaseq/README.txt',
-    'figures/chipseq/README.txt',
-]
+
+# TEST SETTINGS: here we're avoiding adding the full RNA-seq and ChIP-seq
+# outputs to the DAG, because it will trigger the other workflows in their
+# entirety and we don't have that much time on Travis-CI.
+# READMES += [
+#     'figures/rnaseq/README.txt',
+#     'figures/chipseq/README.txt',
+# ]
 
 rule all:
     input:
@@ -70,9 +74,12 @@ rule all:
 
 rule peak_count:
     # This rule depends on *all* the peaks called by the chipseq workflow,
-    # which we can get by accessing the targets of that workflow, like this:
+    # which we can get by accessing the targets of that workflow, like this.
+
+    # TEST SETTINGS: Note that we're only grabbing the first one, to avoid
+    # doing lots of work during the testing of this workflow.
     input:
-        chipseq(utils.flatten(chipseq_config.targets['peaks']))
+        chipseq(utils.flatten(chipseq_config.targets['peaks']))[0]
     output:
         readme_for('peak_count.py')
     script:

--- a/workflows/figures/Snakefile
+++ b/workflows/figures/Snakefile
@@ -72,12 +72,12 @@ rule all:
         [os.path.join('figures/rnaseq', os.path.basename(i)) for i in utils.flatten(rnaseq_config.targets['downstream'])]
 
 
-rule peak_count:
-    # This rule depends on *all* the peaks called by the chipseq workflow,
-    # which we can get by accessing the targets of that workflow, like this.
+# This rule depends on *all* the peaks called by the chipseq workflow,
+# which we can get by accessing the targets of that workflow, like this.
 
-    # TEST SETTINGS: Note that we're only grabbing the first one, to avoid
-    # doing lots of work during the testing of this workflow.
+# TEST SETTINGS: Note that we're only grabbing the first one, to avoid
+# doing lots of work during the testing of this workflow.
+rule peak_count:
     input:
         chipseq(utils.flatten(chipseq_config.targets['peaks']))[0]
     output:

--- a/workflows/figures/packager.sh
+++ b/workflows/figures/packager.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -x
+FILENAME=$(date +%Y%m%d_%H%M)_package.zip
+OUTDIR=packages
+mkdir -p $OUTDIR
+rm -rf bundle
+mkdir bundle
+
+cat /dev/null > FILES
+find figures >> FILES
+find *html >> FILES
+find *png >> FILES
+rsync -rvL --files-from=FILES . bundle
+zip -r "$FILENAME" bundle && mv "$FILENAME" "$OUTDIR" && rm -r bundle FILES

--- a/workflows/figures/scripts/peak_count.py
+++ b/workflows/figures/scripts/peak_count.py
@@ -1,0 +1,26 @@
+import os
+import pandas as pd
+import pybedtools
+
+README = """
+The `peak_counts.tsv` file contains the number of called peaks in each of the
+ChIP-seq peak-calling runs.
+"""
+
+outdir = os.path.dirname(snakemake.output[0])
+if not os.path.exists(outdir):
+    os.makedirs(outdir)
+
+df = []
+for i in snakemake.input:
+    toks = i.split('/')
+    peakcaller = toks[-3]
+    label = toks[-2]
+    df.append(dict(peakcaller=peakcaller, label=label, count=len(pybedtools.BedTool(i))))
+(
+    pd.DataFrame(df)[['peakcaller', 'label', 'count']]
+    .to_csv(os.path.join(outdir, 'peak_counts.tsv'), sep='\t', index=False)
+)
+
+with open(snakemake.output[0], 'w') as fout:
+    fout.write(README)

--- a/workflows/figures/scripts/peaks_at_promoters.py
+++ b/workflows/figures/scripts/peaks_at_promoters.py
@@ -4,6 +4,9 @@ import pybedtools
 import gffutils
 from gffutils import pybedtools_integration
 
+README = """
+"""
+
 outdir = os.path.dirname(snakemake.output[0])
 if not os.path.exists(outdir):
     os.makedirs(outdir)
@@ -31,4 +34,7 @@ for pk in snakemake.input.peaks:
     # Keep track of how many there were; this will be exported in the summary
     df.append(dict(label=label, npks=len(peaks_near_tsses)))
 
-pandas.DataFrame(df)[['label', 'npks']].to_csv(snakemake.output[0], sep='\t', index=False)
+pandas.DataFrame(df)[['label', 'npks']].to_csv(os.path.join(outdir, 'summary.tsv'), sep='\t', index=False)
+
+with open(snakemake.output[0], 'w') as fout:
+    fout.write(README)

--- a/workflows/figures/scripts/peaks_at_promoters.py
+++ b/workflows/figures/scripts/peaks_at_promoters.py
@@ -4,8 +4,13 @@ import pybedtools
 import gffutils
 from gffutils import pybedtools_integration
 
+
+SLOP = 1000
 README = """
-"""
+Identifies peaks at TSSs, +/- {0}bp. Each peak-calling run has a corresponding
+BED file containing the subset of peaks that overlap these TSS regions.  The
+file "summary.tsv" summarizes the number of peaks at promoters at each TSS.
+""".format(SLOP)
 
 outdir = os.path.dirname(snakemake.output[0])
 if not os.path.exists(outdir):
@@ -15,7 +20,7 @@ if not os.path.exists(outdir):
 db = gffutils.FeatureDB(snakemake.input.db)
 tsses = (
     pybedtools_integration.tsses(db, as_bed6=True)
-    .slop(l=1000, r=1000, s=True, genome='dm6')
+    .slop(l=SLOP, r=SLOP, s=True, genome='dm6')
     .saveas(os.path.join(outdir, 'tsses-slop.bed'))
 )
 

--- a/workflows/figures/style.css
+++ b/workflows/figures/style.css
@@ -1,0 +1,934 @@
+/*
+:Author: Chad Skeeters
+:Contact: goobsoft@gmail.com
+
+Stylesheet for use with Docutils/rst2html.
+*/
+
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+}
+
+a:focus {
+  outline: thin dotted #333;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+
+a:hover,
+a:active {
+  outline: 0;
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+img {
+  width: auto\9;
+  height: auto;
+  max-width: 100%;
+  vertical-align: middle;
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+}
+
+@media print {
+  * {
+    color: #000 !important;
+    text-shadow: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+  .ir a:after,
+  a[href^="javascript:"]:after,
+  a[href^="#"]:after {
+    content: "";
+  }
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+  thead {
+    display: table-header-group;
+  }
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+  img {
+    max-width: 100% !important;
+  }
+  @page  {
+    margin: 0.5cm;
+  }
+  h1 {
+    page-break-before:always;
+  }
+  h1.title {
+    page-break-before:avoid;
+  }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+}
+
+body {
+  margin: 40px;
+  margin-right: auto;
+  margin-left: auto;
+  width: 700px;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  color: #333333;
+  background-color: #ffffff;
+}
+
+a {
+  color: #0088cc;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: #005580;
+  text-decoration: underline;
+}
+
+.img-rounded {
+  -webkit-border-radius: 6px;
+     -moz-border-radius: 6px;
+          border-radius: 6px;
+}
+
+.img-polaroid {
+  padding: 4px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+     -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+p {
+  margin: 0 0 10px;
+}
+
+small {
+  font-size: 85%;
+}
+
+strong {
+  font-weight: bold;
+}
+
+em {
+  font-style: italic;
+}
+
+cite {
+  font-style: normal;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit;
+  font-weight: bold;
+  line-height: 20px;
+  color: inherit;
+  text-rendering: optimizelegibility;
+}
+h1 {
+  font-size: 2em;
+  padding-bottom:.2em;
+  border-bottom:1px solid grey;
+}
+h1.title {
+  padding-bottom:1em;
+  border-bottom:0px;
+}
+h2 {
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.3em;
+  font-family:Georgia, serif;
+  font-style:italic;
+  /*font-weight:normal;*/
+}
+
+h4 {
+  font-size: 1.3em;
+}
+
+h5 {
+  font-size: 1.2em;
+}
+
+h6 {
+  font-size: 1.1em;
+}
+
+ul,
+ol {
+  padding: 0;
+  margin: 0 0 10px 25px;
+}
+
+ul ul,
+ul ol,
+ol ol,
+ol ul {
+  margin-bottom: 0;
+}
+
+li {
+  line-height: 20px;
+}
+
+dl {
+  margin-bottom: 20px;
+}
+
+dt,
+dd {
+  line-height: 20px;
+}
+
+dt {
+  font-weight: bold;
+}
+
+dd {
+  margin-left: 10px;
+}
+
+hr {
+  margin: 20px 0;
+  border: 0;
+  border-top: 1px solid #eeeeee;
+  border-bottom: 1px solid #ffffff;
+}
+
+abbr[title],
+abbr[data-original-title] {
+  cursor: help;
+  border-bottom: 1px dotted #999999;
+}
+
+abbr.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
+}
+
+blockquote {
+  padding: 0 0 0 15px;
+  margin: 0 0 20px;
+  border-left: 5px solid #eeeeee;
+}
+
+blockquote p {
+  margin-bottom: 0;
+  font-size: 17.5px;
+  font-weight: 300;
+  line-height: 1.25;
+}
+
+q:before,
+q:after,
+blockquote:before,
+blockquote:after {
+  content: "";
+}
+
+address {
+  display: block;
+  margin-bottom: 20px;
+  font-style: normal;
+  line-height: 20px;
+}
+
+code,
+pre {
+  padding: 0 3px 2px;
+  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+  font-size: 12px;
+  color: #333333;
+  -webkit-border-radius: 3px;
+     -moz-border-radius: 3px;
+          border-radius: 3px;
+}
+
+code {
+  padding: 2px 4px;
+  color: #d14;
+  white-space: nowrap;
+  background-color: #f7f7f9;
+  border: 1px solid #e1e1e8;
+}
+
+pre {
+  display: block;
+  padding: 9.5px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  line-height: 20px;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre;
+  white-space: pre-wrap;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+}
+
+pre.prettyprint {
+  margin-bottom: 20px;
+}
+
+pre code {
+  padding: 0;
+  color: inherit;
+  white-space: pre;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border: 0;
+}
+
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}
+
+table {
+  max-width: 100%;
+  background-color: transparent;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.table {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.table th,
+.table td {
+  padding: 8px;
+  line-height: 20px;
+  text-align: left;
+  vertical-align: top;
+  border-top: 1px solid #dddddd;
+}
+
+.table th {
+  font-weight: bold;
+}
+
+.table thead th {
+  vertical-align: bottom;
+}
+
+.table caption + thead tr:first-child th,
+.table caption + thead tr:first-child td,
+.table colgroup + thead tr:first-child th,
+.table colgroup + thead tr:first-child td,
+.table thead:first-child tr:first-child th,
+.table thead:first-child tr:first-child td {
+  border-top: 0;
+}
+
+.table tbody + tbody {
+  border-top: 2px solid #dddddd;
+}
+
+.table .table {
+  background-color: #ffffff;
+}
+
+.table-condensed th,
+.table-condensed td {
+  padding: 4px 5px;
+}
+
+.table-bordered {
+  border: 1px solid #dddddd;
+  border-collapse: separate;
+  *border-collapse: collapse;
+  border-left: 0;
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+}
+
+.table-bordered th,
+.table-bordered td {
+  border-left: 1px solid #dddddd;
+}
+
+.table-bordered caption + thead tr:first-child th,
+.table-bordered caption + tbody tr:first-child th,
+.table-bordered caption + tbody tr:first-child td,
+.table-bordered colgroup + thead tr:first-child th,
+.table-bordered colgroup + tbody tr:first-child th,
+.table-bordered colgroup + tbody tr:first-child td,
+.table-bordered thead:first-child tr:first-child th,
+.table-bordered tbody:first-child tr:first-child th,
+.table-bordered tbody:first-child tr:first-child td {
+  border-top: 0;
+}
+
+.table-bordered thead:first-child tr:first-child > th:first-child,
+.table-bordered tbody:first-child tr:first-child > td:first-child,
+.table-bordered tbody:first-child tr:first-child > th:first-child {
+  -webkit-border-top-left-radius: 4px;
+          border-top-left-radius: 4px;
+  -moz-border-radius-topleft: 4px;
+}
+
+.table-bordered thead:first-child tr:first-child > th:last-child,
+.table-bordered tbody:first-child tr:first-child > td:last-child,
+.table-bordered tbody:first-child tr:first-child > th:last-child {
+  -webkit-border-top-right-radius: 4px;
+          border-top-right-radius: 4px;
+  -moz-border-radius-topright: 4px;
+}
+
+.table-bordered thead:last-child tr:last-child > th:first-child,
+.table-bordered tbody:last-child tr:last-child > td:first-child,
+.table-bordered tbody:last-child tr:last-child > th:first-child,
+.table-bordered tfoot:last-child tr:last-child > td:first-child,
+.table-bordered tfoot:last-child tr:last-child > th:first-child {
+  -webkit-border-bottom-left-radius: 4px;
+          border-bottom-left-radius: 4px;
+  -moz-border-radius-bottomleft: 4px;
+}
+
+.table-bordered thead:last-child tr:last-child > th:last-child,
+.table-bordered tbody:last-child tr:last-child > td:last-child,
+.table-bordered tbody:last-child tr:last-child > th:last-child,
+.table-bordered tfoot:last-child tr:last-child > td:last-child,
+.table-bordered tfoot:last-child tr:last-child > th:last-child {
+  -webkit-border-bottom-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+  -moz-border-radius-bottomright: 4px;
+}
+
+.table-bordered tfoot + tbody:last-child tr:last-child td:first-child {
+  -webkit-border-bottom-left-radius: 0;
+          border-bottom-left-radius: 0;
+  -moz-border-radius-bottomleft: 0;
+}
+
+.table-bordered tfoot + tbody:last-child tr:last-child td:last-child {
+  -webkit-border-bottom-right-radius: 0;
+          border-bottom-right-radius: 0;
+  -moz-border-radius-bottomright: 0;
+}
+
+.table-bordered caption + thead tr:first-child th:first-child,
+.table-bordered caption + tbody tr:first-child td:first-child,
+.table-bordered colgroup + thead tr:first-child th:first-child,
+.table-bordered colgroup + tbody tr:first-child td:first-child {
+  -webkit-border-top-left-radius: 4px;
+          border-top-left-radius: 4px;
+  -moz-border-radius-topleft: 4px;
+}
+
+.table-bordered caption + thead tr:first-child th:last-child,
+.table-bordered caption + tbody tr:first-child td:last-child,
+.table-bordered colgroup + thead tr:first-child th:last-child,
+.table-bordered colgroup + tbody tr:first-child td:last-child {
+  -webkit-border-top-right-radius: 4px;
+          border-top-right-radius: 4px;
+  -moz-border-radius-topright: 4px;
+}
+
+.table-striped tbody > tr:nth-child(odd) > td,
+.table-striped tbody > tr:nth-child(odd) > th {
+  background-color: #f9f9f9;
+}
+
+.table-hover tbody tr:hover > td,
+.table-hover tbody tr:hover > th {
+  background-color: #f5f5f5;
+}
+
+table td[class*="span"],
+table th[class*="span"],
+.row-fluid table td[class*="span"],
+.row-fluid table th[class*="span"] {
+  display: table-cell;
+  float: none;
+  margin-left: 0;
+}
+
+.hero-unit {
+  padding: 60px;
+  margin-bottom: 30px;
+  font-size: 18px;
+  font-weight: 200;
+  line-height: 30px;
+  color: inherit;
+  background-color: #eeeeee;
+  -webkit-border-radius: 6px;
+     -moz-border-radius: 6px;
+          border-radius: 6px;
+}
+
+.hero-unit h1 {
+  margin-bottom: 0;
+  font-size: 60px;
+  line-height: 1;
+  letter-spacing: -1px;
+  color: inherit;
+}
+
+.hero-unit li {
+  line-height: 30px;
+}
+
+
+/* rst2html default used to remove borders from tables and images */
+.borderless, table.borderless td, table.borderless th {
+  border: 0 }
+
+table.borderless td, table.borderless th {
+  /* Override padding for "table.docutils td" with "! important".
+     The right padding separates the table cells. */
+  padding: 0 0.5em 0 0 ! important }
+
+.first {
+  /* Override more specific margin styles with "! important". */
+  margin-top: 0 ! important }
+
+.last, .with-subtitle {
+  margin-bottom: 0 ! important }
+
+.hidden {
+  display: none }
+
+a.toc-backref {
+  text-decoration: none ;
+  color: black }
+
+blockquote.epigraph {
+  margin: 2em 5em ; }
+
+dl.docutils dd {
+  margin-bottom: 0.5em }
+
+object[type="image/svg+xml"], object[type="application/x-shockwave-flash"] {
+  overflow: hidden;
+}
+
+/* Uncomment (and remove this text!) to get bold-faced definition list terms
+dl.docutils dt {
+  font-weight: bold }
+*/
+
+div.abstract {
+  margin: 2em 5em }
+
+div.abstract p.topic-title {
+  font-weight: bold ;
+  text-align: center }
+
+div.admonition, div.attention, div.caution, div.danger, div.error,
+div.hint, div.important, div.note, div.tip, div.warning {
+  margin: 2em ;
+  border: medium outset ;
+  padding: 1em }
+
+div.note, div.warning {
+  margin:1.5em 0px;
+  border: none;
+}
+
+div.note p.admonition-title,
+div.warning p.admonition-title
+{
+  display:none;
+}
+
+/* Clearfix
+ * http://css-tricks.com/snippets/css/clear-fix/
+ */
+
+div.note:after,
+div.warning:after {
+  content:"";
+  display:table;
+  clear:both;
+}
+
+div.note p:before,
+div.warning p:before {
+  display:block;
+  float:left;
+  font-size:4em;
+  line-height:1em;
+  margin-right:20px;
+  margin-left: 0em;
+  margin-top:-10px;
+  content:'\0270D'; /*handwriting*/
+}
+
+div.warning p:before {
+  content:'\026A0'; /*warning*/
+}
+
+div.admonition p.admonition-title, div.hint p.admonition-title,
+div.important p.admonition-title, div.note p.admonition-title,
+div.tip p.admonition-title {
+  font-weight: bold ;
+  font-family: sans-serif }
+
+div.attention p.admonition-title, div.caution p.admonition-title,
+div.danger p.admonition-title, div.error p.admonition-title,
+div.warning p.admonition-title, .code .error {
+  color: red ;
+  font-weight: bold ;
+  font-family: sans-serif }
+
+/* Uncomment (and remove this text!) to get reduced vertical space in
+   compound paragraphs.
+div.compound .compound-first, div.compound .compound-middle {
+  margin-bottom: 0.5em }
+
+div.compound .compound-last, div.compound .compound-middle {
+  margin-top: 0.5em }
+*/
+
+div.dedication {
+  margin: 2em 5em ;
+  text-align: center ;
+  font-style: italic }
+
+div.dedication p.topic-title {
+  font-weight: bold ;
+  font-style: normal }
+
+div.figure {
+  margin-left: 2em ;
+  margin-right: 2em }
+
+div.footer, div.header {
+  clear: both;
+  font-size: smaller }
+
+div.line-block {
+  display: block ;
+  margin-top: 1em ;
+  margin-bottom: 1em }
+
+div.line-block div.line-block {
+  margin-top: 0 ;
+  margin-bottom: 0 ;
+  margin-left: 1.5em }
+
+div.sidebar {
+  margin: 0 0 0.5em 1em ;
+  border: medium outset ;
+  padding: 1em ;
+  background-color: #ffffee ;
+  width: 40% ;
+  float: right ;
+  clear: right }
+
+div.sidebar p.rubric {
+  font-family: sans-serif ;
+  font-size: medium }
+
+div.system-messages {
+  margin: 5em }
+
+div.system-messages h1 {
+  color: red }
+
+div.system-message {
+  border: medium outset ;
+  padding: 1em }
+
+div.system-message p.system-message-title {
+  color: red ;
+  font-weight: bold }
+
+div.topic {
+  margin: 2em }
+
+h1.section-subtitle, h2.section-subtitle, h3.section-subtitle,
+h4.section-subtitle, h5.section-subtitle, h6.section-subtitle {
+  margin-top: 0.4em }
+
+h1.title {
+  text-align: center }
+
+h2.subtitle {
+  text-align: center }
+
+hr.docutils {
+  width: 75% }
+
+img.align-left, .figure.align-left, object.align-left {
+  clear: left ;
+  float: left ;
+  margin-right: 1em }
+
+img.align-right, .figure.align-right, object.align-right {
+  clear: right ;
+  float: right ;
+  margin-left: 1em }
+
+img.align-center, .figure.align-center, object.align-center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.align-left {
+  text-align: left }
+
+.align-center {
+  clear: both ;
+  text-align: center }
+
+.align-right {
+  text-align: right }
+
+/* reset inner alignment in figures */
+div.align-right {
+  text-align: inherit }
+
+/* div.align-center * { */
+/*   text-align: left } */
+
+ol.simple, ul.simple {
+  margin-bottom: 1em }
+
+ol.arabic {
+  list-style: decimal }
+
+ol.loweralpha {
+  list-style: lower-alpha }
+
+ol.upperalpha {
+  list-style: upper-alpha }
+
+ol.lowerroman {
+  list-style: lower-roman }
+
+ol.upperroman {
+  list-style: upper-roman }
+
+p.attribution {
+  text-align: right ;
+  margin-left: 50% }
+
+p.caption {
+  font-style: italic }
+
+p.credits {
+  font-style: italic ;
+  font-size: smaller }
+
+p.label {
+  white-space: nowrap }
+
+p.rubric {
+  font-weight: bold ;
+  font-size: larger ;
+  color: maroon ;
+  text-align: center }
+
+p.sidebar-title {
+  font-family: sans-serif ;
+  font-weight: bold ;
+  font-size: larger }
+
+p.sidebar-subtitle {
+  font-family: sans-serif ;
+  font-weight: bold }
+
+p.topic-title {
+  font-weight: bold }
+
+pre.address {
+  margin-bottom: 0 ;
+  margin-top: 0 ;
+  font: inherit }
+
+pre.literal-block, pre.doctest-block, pre.math, pre.code {
+  margin-left: 2em ;
+  margin-right: 2em }
+
+pre.code .ln { color: grey; } /* line numbers */
+pre.code, code { background-color: #eeeeee }
+pre.code .comment, code .comment { color: #5C6576 }
+pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
+pre.code .literal.string, code .literal.string { color: #0C5404 }
+pre.code .name.builtin, code .name.builtin { color: #352B84 }
+pre.code .deleted, code .deleted { background-color: #DEB0A1}
+pre.code .inserted, code .inserted { background-color: #A3D289}
+
+span.classifier {
+  font-family: sans-serif ;
+  font-style: oblique }
+
+span.classifier-delimiter {
+  font-family: sans-serif ;
+  font-weight: bold }
+
+span.interpreted {
+  font-family: sans-serif }
+
+span.option {
+  white-space: nowrap }
+
+span.pre {
+  white-space: pre }
+
+span.problematic {
+  color: red }
+
+span.section-subtitle {
+  /* font-size relative to parent (h1..h6 element) */
+  font-size: 80% }
+
+table.citation {
+  border-left: solid 1px gray;
+  margin-left: 1px }
+
+table.docinfo {
+  margin: 2em 4em }
+
+table.docutils {
+  margin-top: 0.5em ;
+  margin-bottom: 0.5em }
+
+table.footnote {
+  border-left: solid 1px black;
+  margin-left: 1px }
+
+table.docutils td, table.docutils th,
+table.docinfo td, table.docinfo th {
+  padding-left: 0.5em ;
+  padding-right: 0.5em ;
+  vertical-align: top }
+
+table.docutils th.field-name, table.docinfo th.docinfo-name {
+  font-weight: bold ;
+  text-align: left ;
+  white-space: nowrap ;
+  padding-left: 0 }
+
+h1 tt.docutils, h2 tt.docutils, h3 tt.docutils,
+h4 tt.docutils, h5 tt.docutils, h6 tt.docutils {
+  font-size: 100% }
+
+ul.auto-toc {
+  list-style-type: none }
+
+.code .pygments-hll { background-color: #ffffcc }
+.code .pygments-c { color: #60a0b0; font-style: italic } /* Comment */
+.code .pygments-err { border: 1px solid #FF0000 } /* Error */
+.code .pygments-k { color: #007020; font-weight: bold } /* Keyword */
+.code .pygments-o { color: #666666 } /* Operator */
+.code .pygments-cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.code .pygments-cp { color: #007020 } /* Comment.Preproc */
+.code .pygments-c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.code .pygments-cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.code .pygments-gd { color: #A00000 } /* Generic.Deleted */
+.code .pygments-ge { font-style: italic } /* Generic.Emph */
+.code .pygments-gr { color: #FF0000 } /* Generic.Error */
+.code .pygments-gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.code .pygments-gi { color: #00A000 } /* Generic.Inserted */
+.code .pygments-go { color: #888888 } /* Generic.Output */
+.code .pygments-gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.code .pygments-gs { font-weight: bold } /* Generic.Strong */
+.code .pygments-gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.code .pygments-gt { color: #0044DD } /* Generic.Traceback */
+.code .pygments-kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.code .pygments-kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.code .pygments-kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.code .pygments-kp { color: #007020 } /* Keyword.Pseudo */
+.code .pygments-kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.code .pygments-kt { color: #902000 } /* Keyword.Type */
+.code .pygments-m { color: #40a070 } /* Literal.Number */
+.code .pygments-s { color: #4070a0 } /* Literal.String */
+.code .pygments-na { color: #4070a0 } /* Name.Attribute */
+.code .pygments-nb { color: #007020 } /* Name.Builtin */
+.code .pygments-nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.code .pygments-no { color: #60add5 } /* Name.Constant */
+.code .pygments-nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.code .pygments-ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.code .pygments-ne { color: #007020 } /* Name.Exception */
+.code .pygments-nf { color: #06287e } /* Name.Function */
+.code .pygments-nl { color: #002070; font-weight: bold } /* Name.Label */
+.code .pygments-nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.code .pygments-nt { color: #062873; font-weight: bold } /* Name.Tag */
+.code .pygments-nv { color: #bb60d5 } /* Name.Variable */
+.code .pygments-ow { color: #007020; font-weight: bold } /* Operator.Word */
+.code .pygments-w { color: #bbbbbb } /* Text.Whitespace */
+.code .pygments-mf { color: #40a070 } /* Literal.Number.Float */
+.code .pygments-mh { color: #40a070 } /* Literal.Number.Hex */
+.code .pygments-mi { color: #40a070 } /* Literal.Number.Integer */
+.code .pygments-mo { color: #40a070 } /* Literal.Number.Oct */
+.code .pygments-sb { color: #4070a0 } /* Literal.String.Backtick */
+.code .pygments-sc { color: #4070a0 } /* Literal.String.Char */
+.code .pygments-sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.code .pygments-s2 { color: #4070a0 } /* Literal.String.Double */
+.code .pygments-se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.code .pygments-sh { color: #4070a0 } /* Literal.String.Heredoc */
+.code .pygments-si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.code .pygments-sx { color: #c65d09 } /* Literal.String.Other */
+.code .pygments-sr { color: #235388 } /* Literal.String.Regex */
+.code .pygments-s1 { color: #4070a0 } /* Literal.String.Single */
+.code .pygments-ss { color: #517918 } /* Literal.String.Symbol */
+.code .pygments-bp { color: #007020 } /* Name.Builtin.Pseudo */
+.code .pygments-vc { color: #bb60d5 } /* Name.Variable.Class */
+.code .pygments-vg { color: #bb60d5 } /* Name.Variable.Global */
+.code .pygments-vi { color: #bb60d5 } /* Name.Variable.Instance */
+.code .pygments-il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/workflows/figures/updates.rst
+++ b/workflows/figures/updates.rst
@@ -1,0 +1,41 @@
+Summary of experiments
+++++++++++++++++++++++
+
+This report summarizes the results of the figure directory.
+
+*Note: this file is intended to be viewed in an unzipped directory so that the links
+work correctly.*
+
+
+Contents
+========
+.. contents::
+
+Updates
+=======
+
+2017-01-01:
+    - intial build
+
+Jobs
+====
+
+The following figures plot the different jobs for this analysis and their
+dependency structure.  It is useful for verifying that updates to a particular
+job will correctly trigger downstream jobs.
+
+RNA-seq jobs
+------------
+
+.. figure:: rnaseq_dag.png
+
+ChIP-seq jobs
+-------------
+
+.. figure:: chipseq_dag.png
+
+Figures jobs
+------------
+
+.. figure:: figures_dag.png
+


### PR DESCRIPTION
This PR updates the `figures` workflow to reflect what I've been using for a couple of projects now.

The docstring at the top of the Snakefile has some details, but briefly:

- Each script in `scripts/scriptname.py` is expected to create, at a minimum, `figures/scriptname/README.txt` in ReST format. The script can create anything else it needs to, but I generally only track the README as an output in the Snakefile. The README is typically written only at the very end of the script so that everything else in it successfully completes.
- Each script has its own rule in the figures Snakefile; that's where input deps are configured
- The final outputs from rnaseq and chipseq workflows are symlinked over to the figures dir (including their respective multiqc.html files) so that there's a single output location for all of `lcdb-wf` workflows.
- There are rules for plotting PNGs of the DAGs for chipseq, rnaseq, and figures workflows
- A report, `guide.html`, is generated out of the `updates.rst` file (a place to keep track of what changed) as well as the various READMEs and DAG PNGs. `guide.html` also links out to the individual figure directories, so it's convenient for browsing
- `packager.sh` packages up the figures directory and guide into a zip file with the current date, which can then be moved to a server (e.g., helix datashare) for sharing with collaborators.