### PR TITLE
Chipseq additions

### DIFF
--- a/include/WRAPPER_SLURM
+++ b/include/WRAPPER_SLURM
@@ -21,7 +21,7 @@ if [[ ! -e logs ]]; then mkdir -p logs; fi
     --cluster 'sbatch {cluster.prefix} --cpus-per-task={threads}  --output=logs/{rule}.o.%j --error=logs/{rule}.e.%j' \
     --use-conda \
     --configfile config/config.yaml \
-    --latency-wait=60 \
+    --latency-wait=300 \
     ) > "Snakefile.log" 2>&1
 
 SNAKE_PID=$!

--- a/include/bigBroadPeak.as
+++ b/include/bigBroadPeak.as
@@ -1,0 +1,13 @@
+table bigBroadeak
+"BED6+3 Peaks of signal enrichment based on pooled, normalized (interpreted) data."
+(
+    string chrom;        "Reference sequence chromosome or scaffold"
+    uint   chromStart;   "Start position in chromosome"
+    uint   chromEnd;     "End position in chromosome"
+    string name;	 "Name given to a region (preferably unique). Use . if no name is assigned"
+    uint   score;        "Indicates how dark the peak will be displayed in the browser (0-1000) "
+    char[1]  strand;     "+ or - or . for unknown"
+    float  signalValue;  "Measurement of average enrichment for the region"
+    float  pValue;       "Statistical significance of signal value (-log10). Set to -1 if not used."
+    float  qValue;       "Statistical significance with multiple-test correction applied (FDR -log10). Set to -1 if not used."
+)

--- a/include/bigNarrowPeak.as
+++ b/include/bigNarrowPeak.as
@@ -1,0 +1,14 @@
+table bigNarrowPeak
+"BED6+4 Peaks of signal enrichment based on pooled, normalized (interpreted) data."
+(
+    string chrom;        "Reference sequence chromosome or scaffold"
+    uint   chromStart;   "Start position in chromosome"
+    uint   chromEnd;     "End position in chromosome"
+    string name;	 "Name given to a region (preferably unique). Use . if no name is assigned"
+    uint   score;        "Indicates how dark the peak will be displayed in the browser (0-1000) "
+    char[1]  strand;     "+ or - or . for unknown"
+    float  signalValue;  "Measurement of average enrichment for the region"
+    float  pValue;       "Statistical significance of signal value (-log10). Set to -1 if not used."
+    float  qValue;       "Statistical significance with multiple-test correction applied (FDR -log10). Set to -1 if not used."
+    int   peak;         "Point-source called for this peak; 0-based offset from chromStart. Set to -1 if no point-source called."
+)

--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -85,6 +85,9 @@ def merged_input_for_ip(sampletable, merged_ip):
     """
     Returns the merged input label for a merged IP label.
 
+    This is primarily used for the `fingerprint` rule, where we collect all the
+    available input BAMs together.
+
     Parameters
     ----------
 
@@ -93,15 +96,58 @@ def merged_input_for_ip(sampletable, merged_ip):
     merged_ip : str
         Label of IP to use, must be present in the `label` column of the
         sampletable.
+
+    Examples
+    --------
+    This should make more sense if we have an example to work with.....
+
+    Samples ip1 and ip2 are technical replicates. They are from a different
+    experiment than ip3 and input3, hence their different
+    biological_material.
+
+    The way we know that input1 should be paired with ip1 and ip2 is because
+    it shares the same biological material.
+
+    Compare input1 and input9. They are not technical replicates (since they
+    do not share the same `label`) but they are biological replicates because
+    they share the same biological material.
+
+    >>> from io import StringIO
+    >>> import pandas as pd
+    >>> df = pd.read_table(StringIO('''
+    ... samplename  antibody   biological_material  label
+    ... ip1         gaf        s2cell-1             s2cell-gaf-1
+    ... ip2         gaf        s2cell-1             s2cell-gaf-1
+    ... ip3         ctcf       s2cell-2             s2cell-ctcf-1
+    ... input1      input      s2cell-1             s2cell-input-1
+    ... input3      input      s2cell-2             s2cell-input-3
+    ... input9      input      s2cell-1             s2cell-input-9'''),
+    ... sep='\s+')
+
+
+    >>> merged_input_for_ip(df, 's2cell-gaf-1')
+    ['s2cell-input-1', 's2cell-input-9']
+
+    >>> merged_input_for_ip(df, 's2cell-ctcf-1')
+    ['s2cell-input-3']
+
     """
     biomaterial = sampletable.loc[sampletable['label'] == merged_ip, 'biological_material']
 
-    # note that we're printing here in addition to raising a ValueError because
+    # This is a double-check that the merged IP all comes from the same
+    # biological material.
+    #
+    # Note that we're printing here in addition to raising a ValueError because
     # when this is used in an input function to a snakemake rule, the traceback
     # is hidden
+    #
     if biomaterial.nunique() != 1:
         print('Expected a single biomaterial, found: {0}'.format(biomaterial))
         raise ValueError
+
+    # Now we find all the inputs from that biological material -- this is
+    # defined as everything sharing the biological material that has "input" as
+    # its antibody. They should also
     biomaterial = biomaterial.values[0]
     input_label = sampletable.loc[
         (sampletable['biological_material'] == biomaterial) &
@@ -109,12 +155,7 @@ def merged_input_for_ip(sampletable, merged_ip):
         'label'
     ]
 
-    if input_label.nunique() != 1:
-        raise ValueError(
-            "Expected a single input label for biological_material='{1}', "
-            "found {0}. ".format(input_label.tolist(), biomaterial))
-
-    return input_label.values[0]
+    return input_label.tolist()
 
 
 def detect_peak_format(fn):

--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -141,3 +141,20 @@ def inputs_for_ip(sampletable, ip):
         sampletable.columns[0]
     ]
     return list(inputs)
+
+
+def detect_peak_format(fn):
+    """
+    Figure out if a BED file is narrowPeak or broadPeak.
+
+    Returns None if undetermined.
+
+    This is useful for figuring out which autoSql file we should use or which
+    bigBed 6+4 or bigBed 6+3 format to use.
+    """
+    line = open(fn).readline().strip()
+    toks = line.split('\t')
+    if len(toks) == 10:
+        return 'narrowPeak'
+    if len(toks) == 9:
+        return 'broadPeak'

--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -117,32 +117,6 @@ def merged_input_for_ip(sampletable, merged_ip):
     return input_label.values[0]
 
 
-def inputs_for_ip(sampletable, ip):
-    """
-    Returns all inputs with the same biological material as the provided IP
-    sample.
-
-    This can be useful for creating the "chipseq:peak_calling" section of the
-    config.yaml.
-
-    Differs from `merged_input_for_ip` in that here we return *all* inputs on
-    a sample level (first column of the sampletable) while that function
-    expects a 1:1 mapping between *merged* samples (the "label" column of the
-    sampletable).
-    """
-    biomaterial = sampletable.loc[sampletable[sampletable.columns[0]] == ip, 'biomaterial']
-    if biomaterial.nunique() != 1:
-        print('Expected a single biomaterial, found: {0}'.format(biomaterial))
-        raise ValueError
-    biomaterial = biomaterial.values[0]
-    inputs = sampletable.loc[
-        (sampletable['biological_material'] == biomaterial) &
-        (sampletable['antibody'] == 'input'),
-        sampletable.columns[0]
-    ]
-    return list(inputs)
-
-
 def detect_peak_format(fn):
     """
     Figure out if a BED file is narrowPeak or broadPeak.

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ r-knitrbootstrap
 r-pheatmap
 r-readr
 r-rmarkdown
+r-spp
 salmon
 samtools
 snakemake

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ samtools
 snakemake
 subread
 trackhub
+ucsc-bedtobigbed
 ucsc-fetchchromsizes
 ucsc-gtftogenepred
 ucsc-liftover

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -5,11 +5,13 @@ from textwrap import dedent
 import yaml
 import tempfile
 import pandas as pd
+import numpy as np
 import pybedtools
 from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common, chipseq
 from lib.patterns_targets import ChIPSeqConfig
+
 
 # ----------------------------------------------------------------------------
 # Note:
@@ -513,6 +515,7 @@ rule bed_to_bigbed:
             df = pd.read_table(output[0] + '.tmp', index_col=False, names=names)
             df['score'] = df['score'] - df['score'].min()
             df['score'] = (df['score'] / df['score'].max()) * 1000
+            df['score'] = df['score'].replace([np.inf, -np.inf], np.nan).fillna(0)
             df['score'] = df['score'].astype(int)
             df.to_csv(output[0] + '.tmp', sep='\t', index=False, header=False)
 

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -5,6 +5,7 @@ from textwrap import dedent
 import yaml
 import tempfile
 import pandas as pd
+import pybedtools
 from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common, chipseq
@@ -49,7 +50,8 @@ rule targets:
             utils.flatten(c.targets['bigwig']) +
             utils.flatten(c.targets['peaks']) +
             utils.flatten(c.targets['merged_techreps']) +
-            utils.flatten(c.targets['fingerprint'])
+            utils.flatten(c.targets['fingerprint']) +
+            utils.flatten(c.targets['bigbed'])
         )
 
 
@@ -460,40 +462,62 @@ rule spp:
         wrapper_for('spp')
 
 
-# rule bed_to_bigbed:
-#     """
-#     Convert BED to bigBed
-#     """
-#     input: "data/chipseq/peakcalling/{algorithm}/{label}/{prefix}.bed"
-#     output: "data/chipseq/peakcalling/{algorithm}/{label}/{prefix}.bigbed"
-#     log: "data/chipseq/peakcalling/{algorithm}/{label}/{prefix}.bigbed.log"
-#     run:
-#         p = {
-#             'macs2': ('assets/narrowPeak.as', '4+6', _narrowpeak),
-#             'macs2_lenient': ('assets/narrowPeak.as', '4+6', _narrowpeak),
-#             'macs2_broad': ('assets/broadPeak.as', '4+6', _broadpeak),
-#             'spp': ('assets/narrowPeak.as', '6+4', _narrowpeak),
-#         }
-#         _as, bedplus, conversion = p[wildcards.algorithm]
-#
-#         if conversion is not None:
-#             conversion(input[0], input[0] + '.tmp')
-#         else:
-#             shell('cp {input} {input}.tmp')
-#
-#         if len(pybedtools.BedTool(input[0])) == 0:
-#             shell("touch {output}")
-#         else:
-#             shell(
-#                 """sort -k1,1 -k2,2n {input}.tmp | awk -F "\\t" '{{OFS="\\t"; if (($2>0) && ($3>0)) print $0}}' > {input}.tmp.sorted """
-#                 "&& bedToBigBed "
-#                 "-type=bed{bedplus} "
-#                 "-as={_as} "
-#                 "{input}.tmp.sorted "
-#                 "dm6.chromsizes "
-#                 "{output} &> {log} "
-#                 "&& rm {input}.tmp && rm {input}.tmp.sorted")
+rule bed_to_bigbed:
+    """
+    Convert BED to bigBed
+    """
+    input:
+        bed='{prefix}.bed',
+        chromsizes=refdict[c.assembly][config['aligner']['tag']]['chromsizes']
+    output: '{prefix}.bigbed'
+    run:
+        # Based on the filename, identify the algorithm. Based on the contents,
+        # identify the format.
+        algorithm = os.path.basename(os.path.dirname(input.bed))
+        kind = chipseq.detect_peak_format(input.bed)
 
+
+        # bedToBigBed doesn't handle ze
+        if len(pybedtools.BedTool(input.bed)) == 0:
+            shell("touch {output}")
+        else:
+
+            # Sometimes macs2 or spp will stretch outside chromsome boundaries;
+            # negative values will cause BEDTools to complain. So we have to do
+            # a 2-pass fix.
+            #
+            # And we need a genome file for BEDTools for the intersect, which
+            # we create from the input chromsizes file.
+            shell("""awk -F "\\t" '{{OFS="\\t"; print $1, "0", $2}}' {input.chromsizes} > {output}.tmp.genome""")
+
+            shell(
+                "sort -k1,1 -k2,2n {input.bed} | "
+                """awk -F "\\t" '{{OFS="\\t"; if (($2>0) && ($3>0)) print $0}}' | """
+                "bedtools intersect -a - -b {output}.tmp.genome > {output}.tmp"
+            )
+            if kind == 'narrowPeak':
+                _as = '../../include/bigNarrowPeak.as'
+                _type = 'bed6+4'
+                names=[
+                    'chrom', 'chromStart', 'chromEnd', 'name', 'score',
+                    'strand', 'signalValue', 'pValue', 'qValue', 'peak']
+            elif kind == 'broadPeak':
+                _as = '../../include/bigBroadPeak.as'
+                _type = 'bed6+3'
+                names=[
+                    'chrom', 'chromStart', 'chromEnd', 'name', 'score',
+                    'strand', 'signalValue', 'pValue', 'qValue']
+            else:
+                raise ValueError("Unhandled format for {0}".format(input.bed))
+
+            df = pd.read_table(output[0] + '.tmp', index_col=False, names=names)
+            df['score'] = df['score'] - df['score'].min()
+            df['score'] = (df['score'] / df['score'].max()) * 1000
+            df['score'] = df['score'].astype(int)
+            df.to_csv(output[0] + '.tmp', sep='\t', index=False, header=False)
+
+            shell('bedToBigBed -as={_as} -type={_type} {output}.tmp {input.chromsizes} {output}')
+            shell('rm {output}.tmp {output}.tmp.genome')
 
 
 # vim: ft=python

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -108,7 +108,7 @@ rule bowtie2:
         c.patterns['bam'] + '.log'
     params:
         samtools_view_extra='-F 0x04'
-    threads: 6
+    threads: 8
     wrapper:
         wrapper_for('bowtie2/align')
 

--- a/workflows/chipseq/chipseq_trackhub.py
+++ b/workflows/chipseq/chipseq_trackhub.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+
+"""
+Build and upload a track hub of ChIP-seq signals and peaks, with samples, sort
+order, selection matrix, colors, and server info configured in a hub config
+file.
+
+This module assumes particular filename patterns and peak output. Such
+assumptions are indicated in the comments below.
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+import re
+import argparse
+import pandas
+import yaml
+from trackhub.helpers import sanitize
+from trackhub import CompositeTrack, ViewTrack, SubGroupDefinition, Track, default_hub
+from trackhub.helpers import filter_composite_from_subgroups, dimensions_from_subgroups, hex2rgb
+from trackhub.upload import upload_hub
+
+from lib import chipseq
+from lib.patterns_targets import ChIPSeqConfig
+
+
+ap = argparse.ArgumentParser()
+ap.add_argument('config', help='Main config.yaml file')
+args = ap.parse_args()
+
+# Access configured options. See comments in example hub_config.yaml for
+# details
+config = yaml.load(open(args.config))
+hub_config_fn = os.path.join(os.path.dirname(args.config), config['hub_config'])
+hub_config = yaml.load(open(hub_config_fn))
+
+
+hub, genomes_file, genome, trackdb = default_hub(
+    hub_name=hub_config['hub']['name'],
+    short_label=hub_config['hub']['short_label'],
+    long_label=hub_config['hub']['long_label'],
+    email=hub_config['hub']['email'],
+    genome=hub_config['hub']['genome']
+)
+
+c = ChIPSeqConfig(args.config, os.path.join(os.path.dirname(args.config), 'chipseq_patterns.yaml'))
+
+# Set up subgroups based on unique values from columns specified in the config
+df = pandas.read_table(config['sampletable'], comment='#')
+cols = hub_config['subgroups']['columns']
+subgroups = []
+for col in cols:
+    unique = list(df[col].unique())
+    mapping = {
+        sanitize(i, strict=True): sanitize(i, strict=False)
+        for i in unique
+    }
+
+    mapping['NA'] = 'NA'
+
+    s = SubGroupDefinition(
+        name=sanitize(col, strict=True),
+        label=col,
+        mapping=mapping,
+    )
+    subgroups.append(s)
+
+
+# Add subgroups for algorithm and peaks-or-not for easier subsetting and
+# sorting.
+subgroups.append(
+    SubGroupDefinition(
+        name='algorithm', label='algorithm', mapping={
+            'macs2': 'macs2',
+            'spp': 'spp',
+            'NA': 'NA',
+        }))
+
+subgroups.append(
+    SubGroupDefinition(name='peaks', label='peaks', mapping={
+        'yes': 'yes',
+        'no': 'no',
+    }))
+
+# Identify the sort order based on the config, and create a string appropriate
+# for use as the `sortOrder` argument of a composite track.
+to_sort = hub_config['subgroups'].get('sort_order', [])
+to_sort += [sg.name for sg in subgroups if sg.name not in to_sort]
+
+# Add the additional subgroups
+to_sort += ['algorithm', 'peaks']
+
+sort_order = ' '.join([i + '=+' for i in to_sort])
+
+# Identify samples based on config and sampletable
+sample_dir = config['merged_dir']
+samples = df['label']
+
+composite = CompositeTrack(
+    name=hub_config['hub']['name'] + 'composite',
+    short_label='ChIP-seq composite',
+    long_label='ChIP-seq composite',
+    dimensions=dimensions_from_subgroups(subgroups),
+    filterComposite=filter_composite_from_subgroups(subgroups),
+    sortOrder=sort_order,
+    tracktype='bigWig')
+
+signal_view = ViewTrack(
+    name='signalviewtrack', view='signal', visibility='full',
+    tracktype='bigWig', short_label='signal', long_label='signal')
+
+peaks_view = ViewTrack(
+    name='peaksviewtrack', view='peaks', visibility='dense',
+    tracktype='bigBed', short_label='peaks', long_label='peaks')
+
+supplemental_view = ViewTrack(
+    name='suppviewtrack', view='supplemental', visibility='full',
+    tracktype='bigBed', short_label='Supplemental', long_label='Supplemental')
+
+colors = hub_config.get('colors', [])
+
+
+def decide_color(samplename):
+    """
+    Look up the color dictionary in the config and return the first color that
+    matches `samplename`.
+    """
+    for cdict in hub_config.get('colors', []):
+        k = list(cdict.keys())
+        assert len(k) == 1
+        color = k[0]
+        v = cdict[color]
+        for pattern in v:
+            regex = re.compile(pattern)
+            if regex.search(samplename):
+                return hex2rgb(color)
+    return hex2rgb('#000000')
+
+
+for sample in df['label'].unique():
+
+    # ASSUMPTION: bigwig filename pattern
+    bigwig = os.path.join(
+        sample_dir, sample,
+        sample + '.cutadapt.unique.nodups.bam.bigwig')
+
+    subgroup = df[df.loc[:, 'label'] == sample].to_dict('records')[0]
+    subgroup = {
+        sanitize(k, strict=True): sanitize(v, strict=True)
+        for k, v in subgroup.items()
+    }
+    subgroup['algorithm'] = 'NA'
+    subgroup['peaks'] = 'no'
+
+    signal_view.add_tracks(
+        Track(
+            name=sanitize(sample + os.path.basename(bigwig), strict=True),
+            short_label=sample,
+            long_label=sample,
+            tracktype='bigWig',
+            subgroups=subgroup,
+            source=bigwig,
+            color=decide_color(sample),
+            altColor=decide_color(sample),
+            maxHeightPixels='8:35:100',
+            viewLimits='0:500',
+        )
+    )
+
+# The peak-calling runs are effectively keyed by (label, algorithm). There can
+# be multiple samples for each peak-calling run, and there is always at least
+# an IP and an input. However UCSC does not support multiple tags for
+# a subgroup, so we can't just add all relevant tags.
+#
+# One option would be to create a separate composite. However, this would
+# defeat the purpose of including the peaks in the same view such that they can
+# be sorted alongsize the signal. I think a better option is to identify if
+# there is a consistent value across the subgroup columns for the IP samples.
+# If so, add that subgroup.
+#
+# (this will be a bunch of mucking about with pandas dataframes and counting
+# uniques)
+
+pd = chipseq.peak_calling_dict(config)
+
+cols = hub_config['subgroups']['columns']
+
+for (label, algorithm), v in pd.items():
+
+    # only care about the IP
+    sub_df = df[df['label'].isin(v['ip'])]
+
+    # For each configured subgroup column, add it only if there's exactly one
+    # value for these IPs. This will always be the case if there's only one IP
+    # used in the peak-calling run.
+    subgroup = {}
+    for col in df.columns:
+        k = sanitize(col, strict=True)
+        if sub_df[col].nunique() == 1:
+            v = sanitize(sub_df[col].iloc[0], strict=True)
+        else:
+            v = 'NA'
+        subgroup[k] = v
+
+    subgroup['algorithm'] = algorithm
+    subgroup['peaks'] = 'yes'
+
+    # ASSUMPTION: BED filename pattern
+    bed_filename = os.path.join(
+        config['peaks_dir'],
+        algorithm,
+        label,
+        'peaks.bed')
+
+    # ASSUMPTION: bigBed filename pattern
+    bigbed_filename = os.path.join(
+        config['peaks_dir'],
+        algorithm,
+        label,
+        'peaks.bigbed')
+
+    _type = chipseq.detect_peak_format(bed_filename)
+    if _type == 'narrowPeak':
+        tracktype = 'bigNarrowPeak'
+    else:
+        tracktype = 'bigBed'
+    tracktype = 'bigBed'
+
+    peaks_view.add_tracks(
+        Track(
+            name=sanitize(algorithm + label, strict=True),
+            short_label='{0} {1}'.format(algorithm, label),
+            long_label='{0} {1}'.format(algorithm, label),
+            tracktype=tracktype,
+            source=bigbed_filename,
+            subgroups=subgroup,
+            color=decide_color(bigbed_filename),
+            visibility='dense')
+    )
+
+
+supplemental = hub_config.get('supplemental', [])
+if supplemental:
+    composite.add_view(supplemental_view)
+    for block in supplemental:
+        supplemental_view.add_tracks(Track(**block))
+
+
+# Tie everything together
+composite.add_subgroups(subgroups)
+trackdb.add_tracks(composite)
+composite.add_view(signal_view)
+composite.add_view(peaks_view)
+
+# Render and upload using settings from hub config file
+hub.render()
+kwargs = hub_config.get('upload', {})
+upload_hub(hub=hub, **kwargs)

--- a/workflows/chipseq/config/clusterconfig.yaml
+++ b/workflows/chipseq/config/clusterconfig.yaml
@@ -24,3 +24,6 @@ macs2:
 
 fingerprint:
   prefix: "--gres=lscratch:20 --mem=32g"
+
+spp:
+  prefix: "--gres=lscratch:20 --mem=16g --time=4:00:00"

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -1,6 +1,6 @@
-
-# sampletable: TSV file defining sample metadata.
+# NOTE: all paths are relative to the calling Snakefile.
 #
+# sampletable: TSV file defining sample metadata.
 # First column must have header name "samplename".
 sampletable: 'config/sampletable.tsv'
 
@@ -15,6 +15,9 @@ aggregation_dir: 'data/chipseq_aggregation'
 
 # Directory in which merged technical replicates will be stored
 merged_dir: 'data/chipseq_merged'
+
+# File for configuring the track hub
+hub_config: 'config/hub_config.yaml'
 
 # Which key in the `references` dict below to use
 assembly: 'dmel'

--- a/workflows/chipseq/config/hub_config.yaml
+++ b/workflows/chipseq/config/hub_config.yaml
@@ -1,0 +1,52 @@
+hub:
+  name: 'examplechipseq'
+  short_label: 'Example ChIP-seq'
+  long_label: 'Example ChIP-seq'
+  email: 'dalerr@niddk.nih.gov'
+  genome: 'dm6'
+
+upload:
+  host: localhost   # helix.nih.gov
+  user: username
+  rsync_options: '-vprLt --progress'
+  staging: staging
+  remote_dir: '/path/to/upload/example-chipseq/'
+
+subgroups:
+  # The subgroups to use, as specified in column names of sampletable.tsv. The
+  # order matters; they will be used to create dimensions for the composite
+  # track.
+  columns:
+    - antibody
+
+  # The default sort order can be independent of the columns. Anything missing
+  # here will inherit sorting from `columns` above.
+  sort_order:
+    - samplename
+
+# Colors and regular expressions to search against samplenames. These use
+# `regex.search` instead of `regex.match`, so the pattern can be found
+# anywhere.
+#
+# Note that this is a list of one-key dicts. The value of each dict is a list
+# of regexes. The list is prioritized such that the first pattern to match
+# a sample wins.
+colors:
+  - "#4c9985":
+    - gaf
+  - "#555555":
+    - input
+
+# Each dict in the supplemental list will be added to the track hub, under the
+# "supplemental view". The dict for each item in the list will be passed
+# directly to the trackhub.Track() constructor, so anything valid there can be
+# used here.
+supplemental:
+  -
+    name: "myc"
+    short_label: "Myc in Kc"
+    long_label: "Myc in Kc cells from modENCODE"
+    tracktype: "bigWid"
+    url: "https://www.encodeproject.org/files/ENCFF611KAG/@@download/ENCFF611KAG.bigWig"
+    color: "255,0,0"
+    visibility: "full"


### PR DESCRIPTION
We finally have a trackhub with peaks for chipseq . . .

The `bed_to_bigbed` rule detects the format of the output bed files and uses the corresponding autoSql file, which can be found in `include/`. Currently supports narrowPeak from `macs2` and `spp`, and broadPeak from `macs2 --broad`.

The track hub codes figures out which subgroups to add to each bigBed track. For easy cases where a single IP BAM is provided to the peak-calling run, we can just grab the corresponding row in the sampletable, and use the values of the columns for that row as the subgroups. For cases where there are multiple IPs provided, the solution is to only provide the subgroup if there is only a single unique value for a column across all of the IPs provided. Otherwise the subgroup's value is set to `"NA"`.

I think it might be useful to allow, in the peak-calling run config, a new key that allows overrides to the subgroups. I'll have to play around with this a little more.

Also, the bigBeds are colored similarly to the signal tracks, as configured `workflows/chipseq/config/hub_config.yaml`.

**Edit:** This also makes some changes to `lib.chipseq.merged_inputs_for_ip()` to allow multiple labels per biological material.