### PR TITLE
update duplicate handling in chipseq snakefile

### DIFF
--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -280,7 +280,7 @@ rule markduplicates:
     Mark or remove PCR duplicates with Picard MarkDuplicates
     """
     input:
-        bam=rules.bowtie2.output
+        bam=c.patterns['unique']
     output:
         bam=c.patterns['markduplicates']['bam'],
         metrics=c.patterns['markduplicates']['metrics']


### PR DESCRIPTION
chipseq snakefile markdups currently uses bowtie2 bam as input, ignoring the output of unique. this is sporadically detectable as inconsistencies between the step 4 and step 5 libsizes. it can result in several million reads being incorrectly included in the markdups output.

the patch changes the markduplicates rule to use the unique output bam as input.