### PR TITLE
Trackhubs and stranded bigwigs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ variables:
           cd workflows/chipseq
           source activate lcdb-wf-test
           snakemake --configfile config/config.yaml --use-conda -j2 -T -k -p -r
+          python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
 
   references-step: &references-step
       run:
@@ -74,6 +75,7 @@ variables:
           cd workflows/rnaseq
           source activate lcdb-wf-test
           snakemake --configfile config/config.yaml --use-conda -j2 -T -k -p -r
+          python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
 
   # The path needs to be set each time
   set-path: &set-path

--- a/workflows/chipseq/chipseq_trackhub.py
+++ b/workflows/chipseq/chipseq_trackhub.py
@@ -255,4 +255,6 @@ composite.add_view(peaks_view)
 # Render and upload using settings from hub config file
 hub.render()
 kwargs = hub_config.get('upload', {})
-upload_hub(hub=hub, **kwargs)
+
+if kwargs.get('remote_dir', False):
+    upload_hub(hub=hub, **kwargs)

--- a/workflows/chipseq/chipseq_trackhub.py
+++ b/workflows/chipseq/chipseq_trackhub.py
@@ -27,14 +27,13 @@ from lib.patterns_targets import ChIPSeqConfig
 
 ap = argparse.ArgumentParser()
 ap.add_argument('config', help='Main config.yaml file')
+ap.add_argument('hub_config', help='Track hub config YAML file')
 args = ap.parse_args()
 
 # Access configured options. See comments in example hub_config.yaml for
 # details
 config = yaml.load(open(args.config))
-hub_config_fn = os.path.join(os.path.dirname(args.config), config['hub_config'])
-hub_config = yaml.load(open(hub_config_fn))
-
+hub_config = yaml.load(open(args.hub_config))
 
 hub, genomes_file, genome, trackdb = default_hub(
     hub_name=hub_config['hub']['name'],

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -16,9 +16,6 @@ aggregation_dir: 'data/chipseq_aggregation'
 # Directory in which merged technical replicates will be stored
 merged_dir: 'data/chipseq_merged'
 
-# File for configuring the track hub
-hub_config: 'config/hub_config.yaml'
-
 # Which key in the `references` dict below to use
 assembly: 'dmel'
 

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -503,7 +503,7 @@ rule bigwig_neg:
 
 rule bigwig_pos:
     """
-    Create a bigwig for postive-strand reads
+    Create a bigwig for postive-strand reads.
     """
     input:
         bam=c.patterns['bam'],
@@ -523,6 +523,24 @@ rule bigwig_pos:
         '--filterRNAstrand reverse '
         '--normalizeUsing BPM '
         '&> {log}'
+
+
+rule symlink_bigwigs:
+    input:
+        pos=c.patterns['bigwig']['pos'],
+        neg=c.patterns['bigwig']['neg'],
+    output:
+        sense=c.patterns['bigwig']['sense'],
+        antisense=c.patterns['bigwig']['antisense'],
+    run:
+        # TEST SETTINGS:
+        # In our test data, reads mapping to the positive strand correspond to
+        # sense-strand transcripts. If your protocol is reversed, you can map
+        # negative-strand reads to "sense". The track hub creation in
+        # rnaseq_trackhub.py only cares about the `sense` and `antisense`
+        # versions, so you it's cheap to mess around with the symlinking here.
+        utils.make_relative_symlink(input.pos, output.sense)
+        utils.make_relative_symlink(input.neg, output.antisense)
 
 
 rule rnaseq_rmarkdown:

--- a/workflows/rnaseq/config/config.yaml
+++ b/workflows/rnaseq/config/config.yaml
@@ -4,8 +4,6 @@
 # First column must have header name "samplename".
 sampletable: 'config/sampletable.tsv'
 
-hub_config: 'config/test_hub_config.yml'
-
 # sample_dir: directory in which each sample is expected to have its own
 # directory and fastq file[s]. If `sampletable` lists a sample with samplename
 # SAMPLE1, then at least the file $sample_dir/SAMPLE1/SAMPLE1_R1.fastq.gz is

--- a/workflows/rnaseq/config/hub_config.yaml
+++ b/workflows/rnaseq/config/hub_config.yaml
@@ -1,15 +1,17 @@
 hub:
-  name: 'examplechipseq'
-  short_label: 'Example ChIP-seq'
-  long_label: 'Example ChIP-seq'
+  name: 'examplernaseq'
+  short_label: 'Example RNA-seq'
+  long_label: 'Example RNA-seq'
   email: 'dalerr@niddk.nih.gov'
   genome: 'dm6'
 
 upload:
   host: localhost   # helix.nih.gov
-  user: username
-  rsync_options: '-vprLt --progress'
 
+  # If not specified, defaults to current user
+  user:
+  rsync_options: '-vprLt --progress'
+    #
   # Directory to which track hub will be prepared, by making a bunch of
   # symlinks
   staging: staging
@@ -23,7 +25,7 @@ subgroups:
   # order matters; they will be used to create dimensions for the composite
   # track.
   columns:
-    - antibody
+    - group
 
   # The default sort order can be independent of the columns. Anything missing
   # here will inherit sorting from `columns` above.
@@ -39,9 +41,9 @@ subgroups:
 # a sample wins.
 colors:
   - "#4c9985":
-    - gaf
+    - treatment
   - "#555555":
-    - input
+    - control
 
 # Each dict in the supplemental list will be added to the track hub, under the
 # "supplemental view". The dict for each item in the list will be passed

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -51,6 +51,8 @@ rseqc:
 bigwig:
    pos: '{sample_dir}/{sample}/{sample}.cutadapt.bam.pos.bigwig'
    neg: '{sample_dir}/{sample}/{sample}.cutadapt.bam.neg.bigwig'
+   sense: '{sample_dir}/{sample}/{sample}.cutadapt.bam.sense.bigwig'
+   antisense: '{sample_dir}/{sample}/{sample}.cutadapt.bam.antisense.bigwig'
 
 downstream:
    rnaseq: 'downstream/rnaseq.html'

--- a/workflows/rnaseq/rnaseq_trackhub.py
+++ b/workflows/rnaseq/rnaseq_trackhub.py
@@ -132,15 +132,11 @@ for sample in df[df.columns[0]]:
         subgroup['strand'] = direction
         view = sense_signal_view
         if direction == 'antisense':
-            # additional_kwargs['negateValues'] = 'on'
-            # additional_kwargs['viewLimits'] = '-25:0'
-            additional_kwargs['viewLimits'] = '15:0'
+            additional_kwargs['negateValues'] = 'on'
+            additional_kwargs['viewLimits'] = '-25:0'
             view = antisense_signal_view
         else:
-            # if strands were switched....
-            additional_kwargs['negateValues'] = 'on'
-            additional_kwargs['viewLimits'] = '-15:0'
-            # additional_kwargs['viewLimits'] = '0:25'
+            additional_kwargs['viewLimits'] = '0:25'
         view.add_tracks(
             Track(
                 name=sanitize(sample + os.path.basename(bigwig), strict=True),

--- a/workflows/rnaseq/rnaseq_trackhub.py
+++ b/workflows/rnaseq/rnaseq_trackhub.py
@@ -20,14 +20,13 @@ from trackhub.upload import upload_hub
 import argparse
 ap = argparse.ArgumentParser()
 ap.add_argument('config', help='Main config.yaml file')
+ap.add_argument('hub_config', help='Track hub config YAML file')
 args = ap.parse_args()
 
 # Access configured options. See comments in example hub_config.yaml for
 # details
 config = yaml.load(open(args.config))
-hub_config_fn = os.path.join(os.path.dirname(args.config), config['hub_config'])
-hub_config = yaml.load(open(hub_config_fn))
-
+hub_config = yaml.load(open(args.hub_config))
 
 hub, genomes_file, genome, trackdb = default_hub(
     hub_name=hub_config['hub']['name'],

--- a/workflows/rnaseq/rnaseq_trackhub.py
+++ b/workflows/rnaseq/rnaseq_trackhub.py
@@ -174,5 +174,8 @@ composite.add_view(neg_signal_view)
 # Render and upload using settings from hub config file
 hub.render()
 kwargs = hub_config.get('upload', {})
-upload_hub(hub=hub, **kwargs)
-print(hub.url)
+
+# If the hub config specified a remote path, upload there -- otherwise don't do
+# any uploading.
+if kwargs.get('remote_dir', False):
+    upload_hub(hub=hub, **kwargs)

--- a/workflows/rnaseq/rnaseq_trackhub.py
+++ b/workflows/rnaseq/rnaseq_trackhub.py
@@ -36,8 +36,6 @@ hub, genomes_file, genome, trackdb = default_hub(
     genome=hub_config['hub']['genome']
 )
 
-#hub.url = hub_config['hub']['url']
-#hub.remote_fn = hub_config['hub']['remote_fn']
 
 # Set up subgroups based on the configured columns
 df = pandas.read_table(config['sampletable'], comment='#')
@@ -60,7 +58,7 @@ subgroups.append(
     SubGroupDefinition(
         name='strand',
         label='strand',
-        mapping={'pos': 'pos', 'neg': 'neg'}))
+        mapping={'sense': 'sense', 'antisense': 'antisense'}))
 
 
 # Identify the sort order based on the config, and create a string appropriate
@@ -83,15 +81,15 @@ composite = CompositeTrack(
     tracktype='bigWig')
 
 # ASSUMPTION: stranded bigwigs
-pos_signal_view = ViewTrack(
-    name='possignalviewtrack', view='possignal', visibility='full',
-    tracktype='bigWig', short_label='plus strand', long_label='plus strand signal')
-neg_signal_view = ViewTrack(
-    name='negsignalviewtrack', view='negsignal', visibility='full',
-    tracktype='bigWig', short_label='minus strand', long_label='minus strand signal')
+sense_signal_view = ViewTrack(
+    name='sensesignalviewtrack', view='sensesignal', visibility='full',
+    tracktype='bigWig', short_label='sense strand', long_label='sense strand signal')
+antisense_signal_view = ViewTrack(
+    name='antisensesignalviewtrack', view='antisensesignal', visibility='full',
+    tracktype='bigWig', short_label='antisense strand', long_label='antisense strand signal')
 
 supplemental_view = ViewTrack(
-    name='suppviewtrack', view='supplementa', visibility='full',
+    name='suppviewtrack', view='supplementalview', visibility='full',
     tracktype='bigBed', short_label='Supplemental', long_label='Supplemental')
 
 colors = hub_config.get('colors', [])
@@ -116,7 +114,7 @@ def decide_color(samplename):
 
 for sample in df[df.columns[0]]:
     # ASSUMPTION: stranded bigwigs
-    for direction in 'pos', 'neg':
+    for direction in 'sense', 'antisense':
 
         # ASSUMPTION: bigwig filename pattern
         bigwig = os.path.join(
@@ -132,12 +130,12 @@ for sample in df[df.columns[0]]:
         # ASSUMPTION: stranded bigwigs
         additional_kwargs = {}
         subgroup['strand'] = direction
-        view = pos_signal_view
-        if direction == 'neg':
+        view = sense_signal_view
+        if direction == 'antisense':
             # additional_kwargs['negateValues'] = 'on'
             # additional_kwargs['viewLimits'] = '-25:0'
             additional_kwargs['viewLimits'] = '15:0'
-            view = neg_signal_view
+            view = antisense_signal_view
         else:
             # if strands were switched....
             additional_kwargs['negateValues'] = 'on'
@@ -168,8 +166,8 @@ if supplemental:
 # Tie everything together
 composite.add_subgroups(subgroups)
 trackdb.add_tracks(composite)
-composite.add_view(pos_signal_view)
-composite.add_view(neg_signal_view)
+composite.add_view(sense_signal_view)
+composite.add_view(antisense_signal_view)
 
 # Render and upload using settings from hub config file
 hub.render()


### PR DESCRIPTION
## bigWig strandedness

If using a TruSeq kit (where pos strand corresponds to antisense transcription), you had to either muck around in `rnaseq_trackhub.py` to get things configured correctly (possibly messing up the track labels), or change the params for deepTools bamCoverage to filter out a different strand.

To make this less annoying, there are now *pos* and *neg* bigWigs as well as *sense* and *antisense* symlinks.

We're now operating under the following assumptions:

- deepTools **always** generates bigWigs with "pos" in the extension for reads mapping to the positive strand of the reference and bigWigs with "neg" in the extension for reads mapping to the negative strand of the reference. *This is independent of sense or antisense transcription*.
- `rnaseq_trackhub` **only** pays attention to *sense* and *antisense* bigWigs.

Default behavior is to symlink *pos* bigWigs to *sense* bigWig, corresponding to kits where positive strand is sense transcription.  If you want to switch 'em around, in the new `symlink_bigwigs` rule change

```python
utils.make_relative_symlink(input.pos, output.sense)                                                                                                                                                                                                         
utils.make_relative_symlink(input.neg, output.antisense)
```
 to

```python
utils.make_relative_symlink(input.neg, output.sense)                                                                                                                                                                                                         
utils.make_relative_symlink(input.pos, output.antisense)
```

and then force-rerun the rule (e.g., `snakemake --forcerun symlink_bigwigs`). Operating on symlinks this way makes it cheap to play around to get things right.

## Other changes
The remainder of this PR gets the trackhub generation scripts for both chipseq and rnaseq in better shape, specifically:

- When running `chipseq_trackhub.py` and `rnaseq_trackhub.py`, need to specify first the main config file and then the hub config file. This avoids some mild annoyances in path handling.
- Fix which bigWigs get negated values in `rnaseq_trackhub.py`
- If `upload: remote_dir:` is not specified in the hub config, then no rsync is performed. This lets us test the trackhub generation.
- Speaking of which, the track hub generation is now tested, at least to create the `staging` directory with all the required symlinks
