### PR TITLE
bundle symlinks so the rule only runs once

### DIFF
--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -58,14 +58,20 @@ rule targets:
 
 
 if 'orig_filename' in c.sampletable.columns:
+
+    # Convert the sampletable to be indexed by the first column, for
+    # convenience in generating the input/output filenames.
+    _st = c.sampletable.set_index(c.sampletable.columns[0])
+
     rule symlinks:
         """
         Symlinks files over from original filename
         """
-        input: lambda wc: c.sampletable.set_index(c.sampletable.columns[0])['orig_filename'].to_dict()[wc.sample]
-        output: c.patterns['fastq']
+        input: [_st.loc[sample, 'orig_filename']  for sample in _st.index ]
+        output: [c.patterns['fastq'].format(sample=sample, sample_dir=c.sample_dir) for sample in _st.index]
         run:
-            utils.make_relative_symlink(input[0], output[0])
+            for i, o in zip(input, output):
+                utils.make_relative_symlink(i, o)
 
     rule symlink_targets:
         input: c.targets['fastq']


### PR DESCRIPTION
In some cases we were running into problems where the symlink generation was getting confused about filenames. I haven't been able to reliably reproduce it, but I think this should address the issue and is an improvement anyway.

Instead of running once per fastq, the symlinking rule runs just once and does all the symlinks in one shot. Without wildcards in the input/output, we should avoid any confusion.