### PR TITLE
add clustered heatmaps for chipseq

### DIFF
--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -52,7 +52,9 @@ rule targets:
             utils.flatten(c.targets['peaks']) +
             utils.flatten(c.targets['merged_techreps']) +
             utils.flatten(c.targets['fingerprint']) +
-            utils.flatten(c.targets['bigbed'])
+            utils.flatten(c.targets['bigbed']) +
+            utils.flatten(c.targets['multibigwigsummary']) +
+            utils.flatten(c.targets['plotcorrelation'])
         )
 
 
@@ -504,6 +506,55 @@ rule bed_to_bigbed:
 
             shell('bedToBigBed -as={_as} -type={_type} {output}.tmp {input.chromsizes} {output}')
             shell('rm {output}.tmp')
+
+
+rule multibigwigsummary:
+    """
+    Summarize the bigWigs across genomic bins
+    """
+    input:
+        c.targets['bigwig']
+    output:
+        npz=c.targets['multibigwigsummary']['npz'],
+        tab=c.targets['multibigwigsummary']['tab']
+    run:
+        # from the input files, figure out the sample name.
+        labels = ' '.join([i.split('/')[-2] for i in input])
+        shell(
+            'multiBigwigSummary '
+            'bins '
+            '-b {input} '
+            '--labels {labels} '
+            '-out {output.npz} '
+            '--outRawCounts {output.tab}'
+        )
+
+
+rule plotcorrelation:
+    """
+    Plot a heatmap of correlations across all samples
+    """
+    input:
+        c.targets['multibigwigsummary']['npz']
+    output:
+        heatmap=c.targets['plotcorrelation']['heatmap'],
+        tab=c.targets['plotcorrelation']['tab']
+    shell:
+        'plotCorrelation '
+        '--corData {input} '
+        '--corMethod spearman '
+        '--whatToPlot heatmap '
+        '--plotFile {output.heatmap} '
+        '--colorMap viridis '
+        '--outFileCorMatrix {output.tab}'
+
+        # TEST SETTINGS:
+        # If you're expecting negative correlation, try a divergent colormap
+        # and setting the min/max to ensure that the colomap is centered on zero
+        # '--colorMap RdBu_r '
+        # '--zMin -1 '
+        # '--zMax 1 '
+
 
 
 # vim: ft=python

--- a/workflows/chipseq/config/chipseq_patterns.yaml
+++ b/workflows/chipseq/config/chipseq_patterns.yaml
@@ -34,6 +34,13 @@ patterns_by_sample:
     raw_counts: '{agg_dir}/fingerprints/{ip_label}/{ip_label}_fingerprint.tab'
     metrics: '{agg_dir}/fingerprints/{ip_label}/{ip_label}_fingerprint.metrics'
 
+  multibigwigsummary:
+    npz: '{agg_dir}/deeptools/multibigwigsummary_matrix.npz'
+    tab: '{agg_dir}/deeptools/multibigwigsummary.tab'
+  plotcorrelation:
+    tab: '{agg_dir}/deeptools/plotcorrelation.tab'
+    heatmap: '{agg_dir}/deeptools/correlation_heatmap.png'
+
 patterns_by_peaks:
     peaks:
        macs2: '{peak_calling}/macs2/{macs2_run}/peaks.bed'


### PR DESCRIPTION
This PR uses deepTools' `multiBigwigSummary` and `plotCorrelation` on the generated bigWigs to get a clustered heatmap of chipseq samples.

In addition to a PNG heatmap (currently configured as `{agg_dir}/deeptools/correlation_heatmap.png`), there's also a TSV correlation matrix (`{agg_dir}/deeptools/plotcorrelation.tab`). The idea is that this TSV can be easily incorporated into whatever ChIP-seq report we end up creating.