### PR TITLE
add support for preseq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ multiqc
 pandas
 pandoc
 picard
+preseq
 pybedtools
 pysam
 pytest

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -49,7 +49,8 @@ rule targets:
             utils.flatten(c.targets['rrna']) +
             utils.flatten(c.targets['markduplicates']) +
             utils.flatten(c.targets['salmon']) +
-            #utils.flatten(c.targets['dupradar']) +
+            utils.flatten(c.targets['dupradar']) +
+            utils.flatten(c.targets['preseq']) +
             utils.flatten(c.targets['rseqc']) +
             utils.flatten(c.targets['collectrnaseqmetrics']) +
             utils.flatten(c.targets['bigwig']) +
@@ -348,6 +349,8 @@ rule multiqc:
             utils.flatten(c.targets['salmon']) +
             utils.flatten(c.targets['rseqc']) +
             utils.flatten(c.targets['fastq_screen']) +
+            utils.flatten(c.targets['dupradar']) +
+            utils.flatten(c.targets['preseq']) +
             utils.flatten(c.targets['collectrnaseqmetrics'])
         ),
         config='config/multiqc_config.yaml'
@@ -432,6 +435,20 @@ rule collectrnaseqmetrics:
         'INPUT={input.bam} '
         'OUTPUT={output.metrics} '
         '&> {log}'
+
+rule preseq:
+    """
+    Compute a library complexity curve with preseq
+    """
+    input:
+        bam=c.patterns['bam']
+    output:
+        c.patterns['preseq']
+    shell:
+        'preseq '
+        'c_curve '
+        '-B {input} '
+        '-o {output} '
 
 
 rule dupRadar:

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -46,6 +46,8 @@ dupradar:
    model: '{sample_dir}/{sample}/dupradar/{sample}_model.txt'
    curve: '{sample_dir}/{sample}/dupradar/{sample}_curve.txt'
 
+preseq: '{sample_dir}/{sample}/{sample}_preseq_c_curve.txt'
+
 salmon: '{sample_dir}/{sample}/{sample}.salmon/quant.sf'
 
 rseqc:


### PR DESCRIPTION
MultiQC has a module for preseq, used for estimating library complexity, might as well use it!

Note: `preseq lc_extrap` give errors on the test data, despite messing around with params. Based on the [pdf manual](http://smithlabresearch.org/wp-content/uploads/manual.pdf), it seems reasonable to guess just continuing the `c_curve` on its last trajectory should give a rough estimate of complexity in future experiments. So I don't think it's critical to include here.

This PR also re-enables dupRadar, another library complexity estimator that uses reads counted in genes. The dupRadar plots are not incorporated into the MultiQC report -- they just live in the sample dirs.
