### PR TITLE
add support for downloading directly from SRA

### DIFF
--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -69,6 +69,26 @@ if 'orig_filename' in c.sampletable.columns:
     rule symlink_targets:
         input: c.targets['fastq']
 
+if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('SRR')) > 1:
+
+    # Convert the sampletable to be indexed by the first column, for
+    # convenience in generating the input/output filenames.
+    _st = c.sampletable.set_index(c.sampletable.columns[0])
+
+    rule fastq_dump:
+        output:
+            c.patterns['fastq']
+        run:
+            srr = _st.loc[wildcards.sample, 'Run']
+            shell(
+                'fastq-dump '
+                '{srr} '
+                '-Z '
+                '| gzip -c > {output}.tmp '
+                '&& mv {output}.tmp {output} '
+            )
+
+
 
 rule cutadapt:
     """

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -97,8 +97,6 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
             )
 
 
-
-
 rule cutadapt:
     """
     Run cutadapt

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -77,6 +77,27 @@ if 'orig_filename' in c.sampletable.columns:
     rule symlink_targets:
         input: c.targets['fastq']
 
+if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('SRR')) > 1:
+
+    # Convert the sampletable to be indexed by the first column, for
+    # convenience in generating the input/output filenames.
+    _st = c.sampletable.set_index(c.sampletable.columns[0])
+
+    rule fastq_dump:
+        output:
+            c.patterns['fastq']
+        run:
+            srr = _st.loc[wildcards.sample, 'Run']
+            shell(
+                'fastq-dump '
+                '{srr} '
+                '-Z '
+                '| gzip -c > {output}.tmp '
+                '&& mv {output}.tmp {output} '
+            )
+
+
+
 
 rule cutadapt:
     """
@@ -435,6 +456,7 @@ rule collectrnaseqmetrics:
         'INPUT={input.bam} '
         'OUTPUT={output.metrics} '
         '&> {log}'
+
 
 rule preseq:
     """


### PR DESCRIPTION
If a sampletable has the column "Run" (case-sensitive) and at least one item in it starts with "SRR", then assume that column refers to SRA runs, and download the data directly from SRA, gzip it, and put it into the sample dirs.

This means you can download a table from the SRA Run Selector, add your own first column that the workflow will use to create sample directories, and use the sampletable for downstream RNA-seq DE with no further changes.

This also opens up the possibility of supplying example config files + sample tables that are also tested on biowulf to generate example outputs to demonstrate output.

Note that this functionality is NOT yet tested on CircleCI. Not quite sure how to do that yet. Maybe have a separate task in the CircleCI workflow that only does `snakemake -U fastq_dump`, with test settings to only take 10k reads or something?


