### PR TITLE
preprocess files before testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ variables:
         command: |
           cd workflows/chipseq
           source activate lcdb-wf-test
-          snakemake --configfile config/config.yaml --use-conda -j2 -T -k -p -r
+          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
 
   references-step: &references-step
@@ -66,7 +67,8 @@ variables:
         command: |
           cd workflows/references
           source activate lcdb-wf-test
-          snakemake --configfile config/config.yaml --use-conda -j2 -T -k -p -r
+          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
 
   rnaseq-step: &rnaseq-step
       run:
@@ -74,7 +76,8 @@ variables:
         command: |
           cd workflows/rnaseq
           source activate lcdb-wf-test
-          snakemake --configfile config/config.yaml --use-conda -j2 -T -k -p -r
+          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
 
   # The path needs to be set each time

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ variables:
         command: |
           cd workflows/chipseq
           source activate lcdb-wf-test
-          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
 
@@ -67,7 +67,7 @@ variables:
         command: |
           cd workflows/references
           source activate lcdb-wf-test
-          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
 
   rnaseq-step: &rnaseq-step
@@ -76,7 +76,7 @@ variables:
         command: |
           cd workflows/rnaseq
           source activate lcdb-wf-test
-          python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ variables:
         command: |
           cd workflows/chipseq
           source activate lcdb-wf-test
-          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest ../../ci/preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
 
@@ -67,7 +67,7 @@ variables:
         command: |
           cd workflows/references
           source activate lcdb-wf-test
-          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest ../../ci/preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
 
   rnaseq-step: &rnaseq-step
@@ -76,7 +76,7 @@ variables:
         command: |
           cd workflows/rnaseq
           source activate lcdb-wf-test
-          python -m doctest  preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
+          python -m doctest ../../ci/preprocessor.py && python ../../ci/preprocessor.py Snakefile > Snakefile.test
           snakemake -s Snakefile.test --configfile config/config.yaml --use-conda -j2 -T -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
 

--- a/ci/preprocessor.py
+++ b/ci/preprocessor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+"""
+This script is used for preprocessing a file to prepare it for tests.
+
+We often need to run tests with specific parameters that we may not want to use
+in production. Rather than require users edit files to remove those
+test-specific patterns, here we keep the test settings commented out and only
+un-comment when running tests.
+
+First, we look for any line that matches "# [test settings]" (case insensitive,
+with optional surrounding spacing) and an optional signed integer. Any of these
+would work:
+
+    >>> assert matches('# [test settings]')
+    >>> assert matches('#[test settings]')
+    >>> assert matches('# [ test settings ]')
+    >>> assert matches('# [ test settings -1]')
+    >>> assert matches('# [ test settings +2]')
+    >>> assert matches('# [ TEST SETTINGS +2]')
+    >>> assert matches('# [ TeSt SeTTiNgS +2   ]')
+
+If a lines does not match, output it as-is.
+
+If a line matches, then uncomment it. Specifically, remove the first "#" in the
+line; if it was followed by exactly one space, then remove that too.
+
+If a line matches and a signed integer was provided, then consider it
+a relative location, and then comment-out the referred-to line. Example:
+
+    >>> preprocess('''
+    ... use this for production
+    ... # use this for tests  # [test settings -1]
+    ... '''.splitlines(True))
+    <BLANKLINE>
+    # use this for production
+    use this for tests  # [test settings -1]
+    <BLANKLINE>
+
+If the matched special string creates the first "#" in the line, then do
+nothing to that line but still respect the relative locations. Useful for just
+commenting out nearby lines for tests:
+
+    >>> preprocess('''
+    ... # [TEST SETTINGS +1]
+    ... comment out for testing'''.splitlines(True))
+    <BLANKLINE>
+    # [TEST SETTINGS +1]
+    # comment out for testing
+"""
+
+import re
+regexp = re.compile(r'#\s?\[\s?test settings\s?(?P<rel>[-+]*\d)?\s*\]')
+
+
+def matches(line):
+    return regexp.search(line.lower()) is not None
+
+
+def comment_line(line):
+    """
+    Adds a "#" just before the first non-whitespace character of a line.
+
+    >>> assert comment_line('comment me') == '# comment me'
+    >>> assert comment_line('    me too') == '    # me too'
+    """
+    x = []
+    for i, character in enumerate(line):
+        if character == ' ':
+            x.append(character)
+        else:
+            break
+    x.append('# ')
+    x.extend(line[i:])
+    return ''.join(x)
+
+
+def uncomment_line(line):
+    """
+    Removes the first instance of "#" from a line; if it was followed by
+    exactly one space then remove that too.
+
+    >>> assert uncomment_line('# asdf') == 'asdf'
+    >>> assert uncomment_line('#asdf') == 'asdf'
+    >>> assert uncomment_line('# asdf # but this should be kept') == 'asdf # but this should be kept'
+    >>> assert uncomment_line('#    asdf') == '    asdf'
+    >>> assert uncomment_line('  #    asdf') == '      asdf'
+    """
+    first = line.find('#')
+
+    # If the first comment is the one that flag the line, then do nothing.
+    m = regexp.search(line.lower())
+    if m:
+        if m.start() == first:
+            return line
+
+    if line[first + 1] == ' ' and line[first + 2] != ' ':
+        pattern = '# '
+    else:
+        pattern = '#'
+    return line.replace(pattern, '', 1)
+
+
+def preprocess(lines):
+
+    if isinstance(lines, str):
+        lines = [lines]
+
+    # These lists will keep track of whether a line should be changed.  We need to
+    # create them ahead of time so that we can use relative indexing from line N to
+    # modify the state of lines N-1 or N+1
+    uncomment = [False for i in range(len(lines))]
+    comment = [False for i in range(len(lines))]
+
+    for i, line in enumerate(lines):
+        m = regexp.search(line.lower())
+        if m:
+            # There as at least a "[ test settings ]", so remove comment
+            uncomment[i] = True
+
+            # Figure out if there was also a relative location to uncomment,
+            # and keep track of it in the `comment` list.
+            rel = m.group('rel')
+            if rel is not None:
+                rel = int(rel)
+                comment[i + rel] = True
+
+    result = []
+    for (c, u, line) in zip(comment, uncomment, lines):
+        # E.g., in this situation, unclear what should happen:
+        #
+        #     # [test settings]
+        #     # [test settings -1]
+        #
+        if c and u:
+            raise ValueError("Line {0} is trying to be both commented and uncommented".format(line))
+        if c:
+            result.append(comment_line(line))
+        elif u:
+            result.append(uncomment_line(line))
+        else:
+            result.append(line)
+    print(''.join(result))
+
+
+if __name__ == "__main__":
+    import argparse
+    ap = argparse.ArgumentParser(usage=__doc__)
+    ap.add_argument('infile', help='Input file to modify. Modified file printed to stdout.')
+    args = ap.parse_args()
+    lines = open(args.infile).readlines()
+    preprocess(lines)

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -13,11 +13,12 @@ from lib import common, chipseq
 from lib.patterns_targets import ChIPSeqConfig
 
 # ----------------------------------------------------------------------------
-# Note:
 #
-#  Search this file for the string "# TEST SETTINGS" and make necessary edits
-#  before running this on real data.
+# Search for the string "NOTE:" to look for points of configuration that might
+# be helpful for your experiment.
+#
 # ----------------------------------------------------------------------------
+
 
 configfile: 'config/config.yaml'
 include: '../references/Snakefile'
@@ -309,10 +310,8 @@ rule markduplicates:
     log:
         c.patterns['markduplicates']['bam'] + '.log'
     params:
-        # TEST SETTINGS:
-        # You may want to use something larger, like "-Xmx24g" for real-world
-        # usage.
-        java_args='-Xmx2g'
+        java_args='-Xmx32g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'picard '
         '{params.java_args} '
@@ -343,10 +342,8 @@ rule merge_techreps:
     log:
         c.patterns['merged_techreps'] + '.log'
     params:
-        # TEST SETTINGS:
-        # You may want to use something larger, like "-Xmx24g" for real-world
-        # usage.
-        java_args='-Xmx2g'
+        java_args='-Xmx32g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     wrapper:
         wrapper_for('combos/merge_and_dedup')
 
@@ -373,10 +370,10 @@ rule bigwig:
         '-p {threads} '
         '--minMappingQuality 20 '
         '--ignoreDuplicates '
-        # TEST SETTINGS:
-        # Uncomment the next line in practice; can't use for testing due to
-        # <1000 reads total.
-        # '--normalizeUsing CPM '
+        # Can't use the following normalization for testing due to <1000 reads
+        # total in example data.
+        # [TEST SETTINGS +1]
+        '--normalizeUsing CPM '
         '--extendReads 300 '
         '&> {log}'
 
@@ -403,19 +400,18 @@ rule fingerprint:
         'plotFingerprint '
         '--bamfiles {input.bams} '
         '-p {threads} '
-        # TEST SETTINGS:
-        # This argument is disabled for testing as it dramatically increases
-        # the run time.
-        #'--JSDsample {input.control} '
+        # The JSDsample argument is disabled for testing as it dramatically
+        # increases the run time.
+        # [TEST SETTINGS +1]
+        '--JSDsample {input.control} '
         '--smartLabels '
         '--extendReads=300 '
         '--skipZeros '
         '--outQualityMetrics {output.metrics} '
         '--outRawCounts {output.raw_counts} '
         '--plotFile {output.plot} '
-        # TEST SETTINGS: You'll probably want to change --numberOfSamples to
-        # something higher (default is 500k) when running on real data
-        '--numberOfSamples 50 '
+        # Default is 500k; use fewer to speed up testing:
+        # '--numberOfSamples 50 '  # [TEST SETTINGS ]
         '&> {log} '
         '&& sed -i "s/NA/0.0/g" {output.metrics} '
 
@@ -475,9 +471,9 @@ rule spp:
         c.patterns['peaks']['spp'] + '.log'
     params:
         block=lambda wc: chipseq.block_for_run(config, wc.spp_run, 'spp'),
-        # TEST SETTINGS: probably want to uncomment this:
-        # java_args='-Xmx24g',
         keep_tempfiles=False
+        java_args='-Xmx24g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     threads: 2
     wrapper:
         wrapper_for('spp')
@@ -568,9 +564,9 @@ rule plotcorrelation:
         '--colorMap viridis '
         '--outFileCorMatrix {output.tab}'
 
-        # TEST SETTINGS:
-        # If you're expecting negative correlation, try a divergent colormap
-        # and setting the min/max to ensure that the colomap is centered on zero
+        # Note: if you're expecting negative correlation, try a divergent
+        # colormap and setting the min/max to ensure that the colomap is
+        # centered on zero:
         # '--colorMap RdBu_r '
         # '--zMin -1 '
         # '--zMax 1 '

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -471,9 +471,9 @@ rule spp:
         c.patterns['peaks']['spp'] + '.log'
     params:
         block=lambda wc: chipseq.block_for_run(config, wc.spp_run, 'spp'),
-        keep_tempfiles=False
-        java_args='-Xmx24g'
-        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
+        keep_tempfiles=False,
+        java_args='-Xmx24g',
+        # java_args='-Xmx2g',  # [TEST SETTINGS -1]
     threads: 2
     wrapper:
         wrapper_for('spp')

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -11,11 +11,13 @@ from lib import common
 from lib.patterns_targets import RNASeqConfig
 
 # ----------------------------------------------------------------------------
-# Note:
 #
-#  Search this file for the string "# TEST SETTINGS" and make necessary edits
-#  before running this on real data.
+# Search for the string "NOTE:" to look for points of configuration that might
+# be helpful for your experiment.
+#
 # ----------------------------------------------------------------------------
+
+
 configfile: 'config/config.yaml'
 include: '../references/Snakefile'
 
@@ -202,8 +204,8 @@ rule fastq_screen:
     """
     Run fastq_screen to look for contamination from other genomes
     """
-    # TEST SETTINGS:
-    # May want to add other genomes as appropriate for your experiment
+    # NOTE: you may want to add other genomes as appropriate for your
+    # experiment
     input:
         fastq=rules.cutadapt.output.fastq,
         dm6=c.refdict['dmel'][config['aligner']['tag']]['bowtie2'],
@@ -230,13 +232,14 @@ rule featurecounts:
     log:
         '{sample_dir}/{sample}/{sample}.cutadapt.bam.featurecounts.{stranded}.txt.log'
     shell:
-        # TEST SETTINGS:
-        # By default, the strand argument (-s0, -s1, -s2) to featureCounts is
-        # pulled straight from the wildcards, and the filenames have been set
-        # up in rnaseq_patterns.yaml.
+        # NOTE:
+        # By default, this rule runs three times, using a different strand
+        # setting each time. The strand argument (-s0, -s1, -s2) to
+        # featureCounts is pulled straight from the wildcards, and the
+        # filenames have been set up in rnaseq_patterns.yaml.
         #
-        # You probably do not want to add your own -s argument below, however
-        # other arguments might be useful, for example, for nascent RNA-seq,
+        # You probably do NOT want to add your own -s argument below, however
+        # other arguments might be useful. For example, for nascent RNA-seq,
         # add '-t gene -g gene_id -f '
         'featureCounts '
 
@@ -404,10 +407,8 @@ rule markduplicates:
     log:
         c.patterns['markduplicates']['bam'] + '.log'
     params:
-        # TEST SETTINGS:
-        # You may want to use something larger, like "-Xmx32g" for real-world
-        # usage.
-        java_args='-Xmx2g'
+        java_args='Xmx32g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'picard '
         '{params.java_args} '
@@ -429,26 +430,22 @@ rule collectrnaseqmetrics:
         metrics=c.patterns['collectrnaseqmetrics']['metrics'],
         pdf=c.patterns['collectrnaseqmetrics']['pdf']
     params:
-        # TEST SETTINGS:
-        # You may want to use something larger, like "-Xmx32g" for real-world
-        # usage.
-        java_args='-Xmx2g',
+        java_args='Xmx32g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     log:
         c.patterns['collectrnaseqmetrics']['metrics'] + '.log'
     shell:
         'picard '
         '{params.java_args} '
         'CollectRnaSeqMetrics '
-        # From the Picard docs:
+        # NOTE: Adjust strandedness appropriately. From the Picard docs:
         #
-        # STRAND=StrandSpecificity
-        #     For strand-specific library prep. For unpaired reads, use
-        #     FIRST_READ_TRANSCRIPTION_STRAND if the reads are expected to be on the
-        #     transcription strand.  Required. Possible values: {NONE,
-        #     FIRST_READ_TRANSCRIPTION_STRAND, SECOND_READ_TRANSCRIPTION_STRAND}
+        #     STRAND=StrandSpecificity For strand-specific library prep. For
+        #     unpaired reads, use FIRST_READ_TRANSCRIPTION_STRAND if the reads
+        #     are expected to be on the transcription strand.  Required.
+        #     Possible values: {NONE, FIRST_READ_TRANSCRIPTION_STRAND,
+        #     SECOND_READ_TRANSCRIPTION_STRAND}
         #
-        # TEST SETTINGS:
-        #   Adjust strandedness appropriately.
         'STRAND=NONE CHART_OUTPUT={output.pdf} '
         'REF_FLAT={input.refflat} '
         'INPUT={input.bam} '
@@ -583,15 +580,19 @@ rule symlink_bigwigs:
         sense=c.patterns['bigwig']['sense'],
         antisense=c.patterns['bigwig']['antisense'],
     run:
-        # TEST SETTINGS:
-        # In our test data, reads mapping to the positive strand correspond to
-        # sense-strand transcripts. If your protocol is reversed, you can map
-        # negative-strand reads to "sense". The track hub creation in
-        # rnaseq_trackhub.py only cares about the `sense` and `antisense`
-        # versions, so you it's cheap to mess around with the symlinking here.
+        # NOTE:
+        #    In our test data, reads mapping to the positive strand correspond
+        #    to sense-strand transcripts. If your protocol is reversed (e.g.,
+        #    TruSeq kits), you can map negative-strand reads to "sense". The
+        #    track hub creation in rnaseq_trackhub.py only cares about the
+        #    `sense` and `antisense` versions, so you it's cheap to mess around
+        #    with the symlinking here.
         utils.make_relative_symlink(input.pos, output.sense)
         utils.make_relative_symlink(input.neg, output.antisense)
 
+        # Use this for TruSeq:
+        # utils.make_relative_symlink(input.pos, output.antisense)
+        # utils.make_relative_symlink(input.neg, output.sense)
 
 rule rnaseq_rmarkdown:
     """


### PR DESCRIPTION
There are cases where, due to our minimal test data and/or test hardware, we need to use particular settings to make the tests work on CircleCI. For example, Java args for MarkDuplicates can't use 32G of allocated memory on CircleCI.

Previously, these restrictions were written right into the code, and it was up to the user to edit them upon using the workflows for actual work. That was not only inconvenient, but could also introduce errors (for example, by forgetting to uncomment the CPM normalization when making RNA-seq bigWigs).

Now, we run the new `ci/preprocessor.py` on the Snakefiles before testing them. The doctests from that script are run immediately before using it on the Snakefiles to minimize errors in the preprocessing.

See the docstring for `ci/preprocessor.py` for details, but briefly it looks for lines with the special string `# [TEST SETTINGS]`. If the first "#" on the line comes before that special string, it is removed so the line is uncommented.

If a line has the special string that includes a signed integer, like `# [TEST SETTINGS +1]` then that integer is a relative index indicating a line should be commented out (in this example, the next line would be commented out).

The net result is that test settings live in lines that are normally commented-out, and files as they live in the repo are production-ready without the need for error-prone editing.

