### PR TITLE
Xmx leading dash in default picard arguments

### DIFF
--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -407,7 +407,7 @@ rule markduplicates:
     log:
         c.patterns['markduplicates']['bam'] + '.log'
     params:
-        java_args='Xmx32g'
+        java_args='-Xmx32g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'picard '

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -430,7 +430,7 @@ rule collectrnaseqmetrics:
         metrics=c.patterns['collectrnaseqmetrics']['metrics'],
         pdf=c.patterns['collectrnaseqmetrics']['pdf']
     params:
-        java_args='Xmx32g'
+        java_args='-Xmx32g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     log:
         c.patterns['collectrnaseqmetrics']['metrics'] + '.log'


### PR DESCRIPTION
Current default Xmx arguments to picard collectrnaseqmetrics and markduplicates lack leading dash.