### PR TITLE
picard java VM memory reduction

### DIFF
--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -407,7 +407,7 @@ rule markduplicates:
     log:
         c.patterns['markduplicates']['bam'] + '.log'
     params:
-        java_args='-Xmx32g'
+        java_args='-Xmx20g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'picard '
@@ -430,7 +430,7 @@ rule collectrnaseqmetrics:
         metrics=c.patterns['collectrnaseqmetrics']['metrics'],
         pdf=c.patterns['collectrnaseqmetrics']['pdf']
     params:
-        java_args='-Xmx32g'
+        java_args='-Xmx20g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     log:
         c.patterns['collectrnaseqmetrics']['metrics'] + '.log'


### PR DESCRIPTION
This is a weird one. I tried actually setting the picard java VM ram to 32g and repeatedly got segfaults, which remained if I increased ram, messed with the clusterconfig ram setting, made there be bigger separation between VM memory and node ram, etc.

What ended up working was _reducing_ the VM ram, based on looking at prior RNAseq snakefiles that had worked ok. I guess this is just some issue with incorrect handling of large memory allocations? Whatever it is, it definitely fixes the issue for me. That being said, I would certainly not object to waiting until this is replicated.