### PR TITLE
dupradar: point embedded featurecounts to tmp

### DIFF
--- a/wrappers/wrappers/dupradar/wrapper.py
+++ b/wrappers/wrappers/dupradar/wrapper.py
@@ -20,6 +20,8 @@ try:
 except KeyError:
     raise ValueError('"paired" must be True or False')
 
+tempdir = tempfile.mkdtemp()
+
 # To avoid issues with png() related to X11 and cairo, we can use bitmap() instead.
 # (thanks
 # http://stackoverflow.com/questions/24999983/
@@ -30,7 +32,7 @@ script = """
 library(dupRadar)
 bam <- "{snakemake.input.bam}"
 gtf <- "{snakemake.input.annotation}"
-dm <- analyzeDuprates(bam, gtf, {stranded_int}, {paired_bool}, {snakemake.threads})
+dm <- analyzeDuprates(bam, gtf, {stranded_int}, {paired_bool}, {snakemake.threads}, tmpDir = "{tempdir}")
 
 dm$mhRate <- (dm$allCountsMulti - dm$allCounts) / dm$allCountsMulti
 bitmap(file="{snakemake.output.multimapping_histogram}")
@@ -87,3 +89,4 @@ write.table(
 
 tmp = tempfile.NamedTemporaryFile(delete=False).name
 helpers.rscript(script, tmp, log=log)
+shell("rm -r {tempdir}")


### PR DESCRIPTION
In the rnaseq workflow, dupradar calls Rsubread/featurecounts, which emits a temporary file in the directory from which the pipeline is run. It's around 500M in my current pipeline, and I don't think it's introducing race conditions or anything but it's impolite and asymptotically problematic.

This proposed fix modifies the dupradar wrapper to: create a temporary directory via python tempfile, pass the directory to dupradar and Rsubread via the hidden "tmpDir" argument, and then clean up the temporary directory when the R run completes.

Note that this fixes the only temporary file I've noticed the dupradar wrapper emitting, but I suppose it's possible there are others that I'm missing that this doesn't fix, as it only passes tmpDir to one internal call to Rsubread.