### PR TITLE
Custom results call using lfcShrink

### DIFF
--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -281,11 +281,11 @@ dds <- DESeq(dds,
 # lfcThreshold, or other alternative hypotheses, or any of the custom analysis methods you can access
 # through results. To get those, you have to call results first, without shrinkage, and then apply lfcShrink.
 
-res.lfcthresh.2 <- results(dds, contrast=c('group', 'Shep', 'GFP'), lfcThreshold=2)
+res.lfcthresh.2 <- results(dds, contrast=c('group', 'treatment', 'control'), lfcThreshold=2)
 
 res.list <- list(
-                 all=lfcShrink(dds, contrast=c('group', 'Shep', 'GFP')),
-                 lfc2=lfcShrink(dds, contrast=c('group', 'Shep', 'GFP'), res=res.lfcthresh.2)
+                 all=lfcShrink(dds, contrast=c('group', 'treatment', 'control')),
+                 lfc2=lfcShrink(dds, contrast=c('group', 'treatment', 'control'), res=res.lfcthresh.2)
                  )
 dds.list <- list(
                  all=dds,

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -267,10 +267,25 @@ dds <- DESeq(dds,
 # will get DE results sections automatically created for each item. The
 # res.list.lookup maps the list names to nicer labels that will be used in
 # headings.
-res.list <- list(
-                 all=lfcShrink(dds, contrast=c('group', 'treatment', 'control')),
-                 lfc2=lfcShrink(dds, contrast=c('group', 'treatment', 'control'), lfcThreshold=2)
 
+# As currently implemented (05 apr 2018), lfcShrink checks its arguments for an existing results
+# table. If it exists, it applies shrinkage to the lfc and se in that table. If it ~doesn't~ exist,
+# it calls results on dds with the syntax
+#
+## res <- results(dds, name=coef)
+# or
+## res <- results(dds, contrast=contrast)
+#
+# It does not pass any further arguments to results, and it doesn't warn you that results-style arguments
+# were unrecognized and ignored. Therefore, lfcShrink does not directly support
+# lfcThreshold, or other alternative hypotheses, or any of the custom analysis methods you can access
+# through results. To get those, you have to call results first, without shrinkage, and then apply lfcShrink.
+
+res.lfcthresh.2 <- results(dds, contrast=c('group', 'Shep', 'GFP'), lfcThreshold=2)
+
+res.list <- list(
+                 all=lfcShrink(dds, contrast=c('group', 'Shep', 'GFP')),
+                 lfc2=lfcShrink(dds, contrast=c('group', 'Shep', 'GFP'), res=res.lfcthresh.2)
                  )
 dds.list <- list(
                  all=dds,
@@ -352,17 +367,27 @@ if (length(res.list) > 1){
           "['UpSet' plot](http://caleydo.org/tools/upset/). These plots show ",
           "the combinatorial overlaps of genes found to be up, down, and any ",
           "changed across the different contrasts performed.")
-    mdcat("### Upregulated UpSet plot:")
+
     ll <- lapply(res.list, get.sig, 'up')
-    upset(fromList(ll), order.by='freq', nsets=length(ll))
+    ll <- ll[lapply(ll, length) > 0]
+    if (length(ll) > 1) {
+        mdcat("### Upregulated UpSet plot:")
+        upset(fromList(ll), order.by='freq', nsets=length(ll))
+    }
 
-    mdcat("### Downregulated UpSet plot:")
     ll <- lapply(res.list, get.sig, 'down')
-    upset(fromList(ll), order.by='freq', nsets=length(ll))
+    ll <- ll[lapply(ll, length) > 0]
+    if (length(ll) > 1) {
+        mdcat("### Downregulated UpSet plot:")
+        upset(fromList(ll), order.by='freq', nsets=length(ll))
+    }
 
-    mdcat("### Changed genes UpSet plot:")
     ll <- lapply(res.list, get.sig, 'changed')
-    upset(fromList(ll), order.by='freq', nsets=length(ll))
+    ll <- ll[lapply(ll, length) > 0]
+    if (length(ll) > 1) {
+        mdcat("### Changed genes UpSet plot:")
+        upset(fromList(ll), order.by='freq', nsets=length(ll))
+    }
 }
 ```
 
@@ -378,6 +403,7 @@ found in each cluster are reported below the plot.
 ```{r, fig.width=12, results='asis', cache=TRUE}
 
 ll <- lapply(res.list, get.sig, 'changed')
+ll <- ll[lapply(ll, length) > 0]
 for (name in names(ll)){
     genes <- ll[[name]]
 


### PR DESCRIPTION
Hopefully it works EVEN BETTER this time.

So the current example in workflows/rnaseq/downstream/rnaseq.Rmd of using lfcThreshold=2 is actually secretly not doing anything different than the example without lfcThreshold specified. This is because lfcShrink ignores results-style arguments other than (exactly one of) coef or contrast. In order to get lfcShrink to work with nonstandard results calls, one must first call results with no shrinkage and the custom analysis request, and then call lfcShrink providing both the dds object and the results table from the separate results call.
And in the process of testing the first fix, several downstream things broke when my test dataset contained no actual DE genes when lfcThreshold=2. This is in upset plot handling and DEGreport patterning after lapply(ll, get.sig) calls.
This patch modifies the existing example to use lfcThreshold=2 and adds in-code comments to explain to the user why there's a standalone call to results. It also follows every lapply(ll, get.sig) call with a paired filter operation to only keep list entries with nonzero length, and skips analyses that are not valid without a certain number of nonempty entries. Note that enrichGO and assorted things still run with empty sig lists but just emit warnings, and do not toxically affect the quality of the html or tsv output.
