### PR TITLE
SICER integration in ChIP-seq. Mappable genome handling in ChIP-seq.

### DIFF
--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -48,6 +48,14 @@ def peak_calling_dict(config, algorithm=None):
             key = key[0]
         if key in d:
             raise ValueError("peak calling run '{0}' already defined".format(key))
+#spike in the genome build listed for a particular annotation in the config file, as default
+#will be overridden by anything specified by the user in the peak caller run
+        chosen_assembly = config['assembly']
+        chosen_build = config['aligner']['tag']
+        reference_genome_build = config['references'][chosen_assembly][chosen_build]['genome_build']
+        block['reference_effective_genome_fraction'] = config['mappability'][reference_genome_build]['proportion']
+        block['reference_effective_genome_count'] = config['mappability'][reference_genome_build]['count']
+        block['reference_genome_build'] = reference_genome_build
         d[key] = block
     return d
 

--- a/lib/patterns_targets.py
+++ b/lib/patterns_targets.py
@@ -141,7 +141,7 @@ class ChIPSeqConfig(SeqConfig):
         # Then the peaks
         #
         # Note: when adding support for new peak callers, add them here.
-        PEAK_CALLERS = ['macs2', 'spp']
+        PEAK_CALLERS = ['macs2', 'spp', 'sicer']
 
         self.patterns_by_peaks = self.patterns['patterns_by_peaks']
         self.targets_for_peaks = {}

--- a/lib/postprocess/dm6.py
+++ b/lib/postprocess/dm6.py
@@ -1,5 +1,10 @@
 from snakemake.shell import shell
 
+def fasta_postprocess_nogzip(origfn, newfn):
+    shell(
+        "cat {origfn} | chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
+        "| gzip -c > {newfn} && rm {origfn}")
+
 def fasta_postprocess(origfn, newfn):
     shell(
           "gunzip -c {origfn} "

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -416,6 +416,32 @@ rule fingerprint:
         '&& sed -i "s/NA/0.0/g" {output.metrics} '
 
 
+rule sicer:
+    """
+    Run the SICER peak caller
+    """
+    input:
+        ip=lambda wc:
+	    expand(
+	        c.patterns['merged_techreps'],
+		label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'ip'),
+		merged_dir=c.merged_dir,
+            ),
+        control=lambda wc:
+            expand(
+	        c.patterns['merged_techreps'],
+	        label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'control'),
+	        merged_dir=c.merged_dir,
+	    ),
+    output:
+        bed=c.patterns['peaks']['sicer']
+    log:
+        c.patterns['peaks']['sicer'] + '.log'
+    params:
+        block=lambda wc: chipseq.block_for_run(config, wc.sicer_run, 'sicer')
+    wrapper:
+        wrapper_for('sicer')
+
 rule macs2:
     """
     Run the macs2 peak caller

--- a/workflows/chipseq/config/chipseq_patterns.yaml
+++ b/workflows/chipseq/config/chipseq_patterns.yaml
@@ -45,6 +45,8 @@ patterns_by_peaks:
     peaks:
        macs2: '{peak_calling}/macs2/{macs2_run}/peaks.bed'
        spp: '{peak_calling}/spp/{spp_run}/peaks.bed'
+       sicer: '{peak_calling}/sicer/{sicer_run}/peaks.bed'
     bigbed:
         macs2: '{peak_calling}/macs2/{macs2_run}/peaks.bigbed'
         spp: '{peak_calling}/spp/{spp_run}/peaks.bigbed'
+        sicer: '{peak_calling}/sicer/{sicer_run}/peaks.bigbed'

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -49,12 +49,34 @@ chipseq:
   # at least a BED file of peaks.
   #
   peak_calling:
+    - label: gaf-embryo-sicer
+      algorithm: sicer
+      ip:
+        - gaf-embryo-1
+      control:
+        - input-embryo-1
+      redundancy_threshold: 1
+      window_size: 200
+      fragment_size: 150
+###optional user-specified override mappable genome proportion
+###if specified here, SICER will use this value instead of the value specific to the genome build
+###if NOT specified here, SICER will use the mappability value for your genome build
+#     effective_genome_fraction: 0.75
+      gap_size: 600
+      fdr: 0.01
+      
+
+
     - label: gaf-embryo-1
       algorithm: macs2
       ip:
         - gaf-embryo-1
       control:
         - input-embryo-1
+###optional user-specified override mappable genome size
+###if specified here, MACS will use this value instead of the value specific to the genome build
+###if NOT specified here, MACS will use the mappability value for your genome build
+      effective_genome_count: 7e7
       extra: '--nomodel --extsize 147'
 
     - label: gaf-embryo-1
@@ -116,9 +138,11 @@ references:
     test:
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.common.gzipped'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
         indexes:
           - 'bowtie2'
+      genome_build: dm6
+
   phix:
     default:
       fasta:
@@ -126,3 +150,59 @@ references:
         postprocess: "lib.postprocess.phix.fasta_postprocess"
         indexes:
           - 'bowtie2'
+
+#these are pulled from various sources, most notably https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
+#these should only be considered approximate. more precise estimates can be generated with specific parameters from
+#individual experiments.
+mappability:
+  dm2:
+    count: 1.2e8
+    proportion: 0.88
+  dm3:
+    count: 1.2e8
+    proportion: 0.88
+  dm6:
+    count: 1.2e8
+    proportion: 0.88
+  hg18:
+    count: 2.7e9
+    proportion: 0.87
+  hg19:
+    count: 2.7e9
+    proportion: 0.87
+  hg38:
+    count: 2.7e9
+    proportion: 0.87
+  mm8:
+    count: 2.3e9
+    proportion: 0.87
+  mm9:
+    count: 2.3e9
+    proportion: 0.87
+  mm10:
+    count: 2.3e9
+    proportion: 0.87
+  rn4:
+    count: 2.2e9
+    proportion: 0.80
+  rn5:
+    count: 2.2e9
+    proportion: 0.76
+  rn6:
+    count: 2.2e9
+    proportion: 0.82
+  sacCer1:
+    count: 1.2e7
+    proportion: 0.95
+  sacCer2:
+    count: 1.2e7
+    proportion: 0.95
+  sacCer3:
+    count: 1.2e7
+    proportion: 0.95
+  pombe:
+    count: 1.2e7
+    proportion: 0.97
+  tair8:
+    count: 1.1e8
+    proportion: 0.95

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,7 +82,7 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.common.gzipped'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/wrappers/wrappers/macs2/callpeak/wrapper.py
+++ b/wrappers/wrappers/macs2/callpeak/wrapper.py
@@ -10,6 +10,13 @@ outdir, basebed = os.path.split(snakemake.output.bed)
 label = snakemake.params.block['label']
 extra = snakemake.params.block.get('extra', '')
 
+effective_genome_count = snakemake.params.block.get('effective_genome_count',
+                                                    snakemake.params.block.get('reference_effective_genome_count', ''))
+
+genome_count_flag = ''
+if effective_genome_count != '':
+    genome_count_flag = ' -g ' + effective_genome_count + ' '
+
 cmds = (
     'macs2 '
     'callpeak '
@@ -17,7 +24,7 @@ cmds = (
     '-t {snakemake.input.ip} '
     '-f BAM '
     '--outdir {outdir} '
-    '--name {label} '
+    '--name {label} ' + genome_count_flag
 )
 # add any per-peak-calling-run extra commands
 cmds += extra

--- a/wrappers/wrappers/sicer/README.md
+++ b/wrappers/wrappers/sicer/README.md
@@ -1,0 +1,59 @@
+# SICER
+
+Wraps the `sicer` program to call ChIP-seq peaks on input BED files.
+
+## Examples
+
+Minimal usage. SICER is the best operating piece of hot garbage you'll ever find.
+It has a completely fixed set of input parameters it requires, hard-coded genome
+data in SICER/lib/GenomeData.py (submit bug report in bioconda if you need
+additions), and it can't be run from the same directory at the same time due to
+hard coded output filenames. It's a proper mess boss.
+
+```python
+rule sicer:
+    input:
+        ip='ip.bed',
+        control='input.bed',
+	redundancy_threshold=1,
+	window_size=200,
+	fragment_size=150,
+	effective_genome_fraction=0.75,
+	gap_size=600,
+	fdr=0.01
+    output:
+        bed='out/peaks.bed'
+    wrapper:
+        'file://path/to/wrapper'
+```
+
+
+## Input
+
+`ip`: single BED for IP
+
+`control`: single BED for input
+
+`redundancy_threshold`: cutoff count above which duplicates are removed
+
+`window_size`: SICER resolution; 200 recommended for histones
+
+`fragment_size`: twice the shift from the beginning to the center of a read
+
+`effective_genome_fraction`: percentage of mappable genome; only set it here if you want to override the genome build in config.yaml
+
+`gap_size`: nonnegative integer multiple of window size. used to merge contiguous regions (higher means more liberal merging).
+
+`fdr`: FDR cutoff for calling significant regions.
+
+## Output
+
+`bed`: BED file of called peaks. This is a delicately processed version of `*island.bed` from SICER.
+
+Other files are created, these can be added as additional named outputs for use
+by downstream rules, however the wrapper only pays attention to
+`snakemake.output.bed`.
+
+
+## Params
+DO NOT USE `extra` FOR THIS RULE. SICER IS A JERK ABOUT PARAMETERS. USE THE NAMED PARAMETERS ABOVE.

--- a/wrappers/wrappers/sicer/environment.yaml
+++ b/wrappers/wrappers/sicer/environment.yaml
@@ -1,0 +1,8 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - sicer
+  - bedtools
+  - ucsc-bedsort

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -1,0 +1,72 @@
+import tempfile
+import os
+import glob
+from snakemake import shell
+
+log = snakemake.log_fmt_shell()
+logfile = None
+redundancy_threshold = snakemake.params.block.get('redundancy_threshold', snakemake.params.get('redundancy_threshold', ''))
+window_size = snakemake.params.block.get('window_size', snakemake.params.get('redundancy_threshold', ''))
+fragment_size = snakemake.params.block.get('fragment_size', snakemake.params.get('fragment_size', ''))
+effective_genome_fraction = snakemake.params.block.get('effective_genome_fraction', snakemake.params.block.get('reference_effective_genome_fraction', ''))
+gap_size = snakemake.params.block.get('gap_size', snakemake.params.get('gap_size', ''))
+fdr = snakemake.params.block.get('fdr', snakemake.params.get('fdr', ''))
+genome_build = snakemake.params.block.get('genome_build', snakemake.params.block.get('reference_genome_build', ''))
+
+if redundancy_threshold == '':
+    raise ValueError("SICER requires the specification of a 'redundancy_threshold'")
+if window_size == '':
+    raise ValueError("SICER requires the specification of a 'window_size'")
+if fragment_size == '':
+    raise ValueError("SICER requires the specification of a 'fragment_size'")
+if effective_genome_fraction == '':
+    raise ValueError("SICER requires the specification of an 'effective_genome_fraction'")
+if gap_size == '':
+    raise ValueError("SICER requires the specification of a 'gap_size'")
+if fdr == '':
+    raise ValueError("SICER requires the specification of an 'fdr'")
+if genome_build == '':
+    raise ValueError("SICER requires the specification of a recognized genome build")
+
+outdir, basebed = os.path.split(snakemake.output.bed)
+label = snakemake.params.block['label']
+
+tmpdir = tempfile.mkdtemp()
+cwd = os.getcwd()
+
+cmds = (
+    'bamToBed -i {snakemake.input.ip} > {tmpdir}/ip.bed ; '
+    'bamToBed -i {snakemake.input.control} > {tmpdir}/in.bed '
+)
+
+shell(cmds)
+
+os.chdir(tmpdir)
+
+cmds = (
+    'SICER.sh {tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} {fragment_size} {effective_genome_fraction} {gap_size} {fdr}'
+)
+
+shell(cmds + ' > tmp.sicer.output 2> tmp.sicer.error')
+
+resultsfile = glob.glob(os.path.join(tmpdir, '*-islands-summary-FDR*'))
+
+if len(resultsfile) == 1:
+    hit = resultsfile[0]
+    basehit = os.path.basename(resultsfile[0])
+else:
+    raise ValueError("No islands-summary-FDR file found!")
+
+os.chdir(cwd)
+
+# Fix the output file so that it conforms to UCSC guidelines
+shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
+shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
+
+shell(
+    "export LC_COLLATE=C; "
+    """awk -F"\\t" '{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, $2, $3-1, {label}, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """
+    "{hit} > {snakemake.output.bed}.tmp "
+    "&& bedSort {snakemake.output.bed}.tmp {snakemake.output.bed}"
+    "&& rm {snakemake.output.bed}.tmp && rm -Rf {tmpdir}"
+)


### PR DESCRIPTION
Adds SICER support to ChIP-seq workflow. Uses new bioconda recipe.

Adds mappable genome fraction support to SICER, by specifying various genome sizes in config and then injecting that information into the run block.

Adds mappable genome count support to MACS2, using similar methods as with SICER.