### PR TITLE
SICER integration and mappable genome handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
- version: 2
+version: 2
 
 variables:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+ version: 2
 
 variables:
 
@@ -155,5 +155,5 @@ workflows:
           filters:
             branches:
               ignore:
-	        - sicer-integration
+                - sicer-integration
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ workflows:
           filters:
             branches:
               ignore:
-	        - sicer-integration
+                - sicer-integration
                 - master
       - references:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,4 +155,5 @@ workflows:
           filters:
             branches:
               ignore:
+	        - sicer-integration
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - sicer-integration
                 - master
       - references:
           requires:
@@ -155,5 +154,4 @@ workflows:
           filters:
             branches:
               ignore:
-                - sicer-integration
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,7 @@ workflows:
           filters:
             branches:
               ignore:
+	        - sicer-integration
                 - master
       - references:
           requires:

--- a/lib/chipseq.py
+++ b/lib/chipseq.py
@@ -48,6 +48,14 @@ def peak_calling_dict(config, algorithm=None):
             key = key[0]
         if key in d:
             raise ValueError("peak calling run '{0}' already defined".format(key))
+#spike in the genome build listed for a particular annotation in the config file, as default
+#will be overridden by anything specified by the user in the peak caller run
+        chosen_assembly = config['assembly']
+        chosen_build = config['aligner']['tag']
+        reference_genome_build = config['references'][chosen_assembly][chosen_build]['genome_build']
+        block['reference_effective_genome_fraction'] = config['mappability'][reference_genome_build]['proportion']
+        block['reference_effective_genome_count'] = config['mappability'][reference_genome_build]['count']
+        block['reference_genome_build'] = reference_genome_build
         d[key] = block
     return d
 

--- a/lib/patterns_targets.py
+++ b/lib/patterns_targets.py
@@ -141,7 +141,7 @@ class ChIPSeqConfig(SeqConfig):
         # Then the peaks
         #
         # Note: when adding support for new peak callers, add them here.
-        PEAK_CALLERS = ['macs2', 'spp']
+        PEAK_CALLERS = ['macs2', 'spp', 'sicer']
 
         self.patterns_by_peaks = self.patterns['patterns_by_peaks']
         self.targets_for_peaks = {}

--- a/lib/postprocess/dm6.py
+++ b/lib/postprocess/dm6.py
@@ -1,5 +1,10 @@
 from snakemake.shell import shell
 
+def fasta_postprocess_nogzip(origfn, newfn):
+    shell(
+        "cat {origfn} | chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
+        "| gzip -c > {newfn} && rm {origfn}")
+
 def fasta_postprocess(origfn, newfn):
     shell(
           "gunzip -c {origfn} "

--- a/lib/postprocess/dm6.py
+++ b/lib/postprocess/dm6.py
@@ -1,13 +1,8 @@
 from snakemake.shell import shell
 
-def fasta_postprocess_nogzip(origfn, newfn):
-    shell(
-        "cat {origfn} | chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
-        "| gzip -c > {newfn} && rm {origfn}")
-
 def fasta_postprocess(origfn, newfn):
     shell(
-          "gunzip -c {origfn} "
+          "gunzip -fc {origfn} "
           "| chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
           "| gzip -c > {newfn} "
           "&& rm {origfn}")

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -416,6 +416,32 @@ rule fingerprint:
         '&& sed -i "s/NA/0.0/g" {output.metrics} '
 
 
+rule sicer:
+    """
+    Run the SICER peak caller
+    """
+    input:
+        ip=lambda wc:
+	    expand(
+	        c.patterns['merged_techreps'],
+		label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'ip'),
+		merged_dir=c.merged_dir,
+            ),
+        control=lambda wc:
+            expand(
+	        c.patterns['merged_techreps'],
+	        label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'control'),
+	        merged_dir=c.merged_dir,
+	    ),
+    output:
+        bed=c.patterns['peaks']['sicer']
+    log:
+        c.patterns['peaks']['sicer'] + '.log'
+    params:
+        block=lambda wc: chipseq.block_for_run(config, wc.sicer_run, 'sicer')
+    wrapper:
+        wrapper_for('sicer')
+
 rule macs2:
     """
     Run the macs2 peak caller

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -422,17 +422,17 @@ rule sicer:
     """
     input:
         ip=lambda wc:
-	    expand(
-	        c.patterns['merged_techreps'],
-		label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'ip'),
-		merged_dir=c.merged_dir,
+            expand(
+                c.patterns['merged_techreps'],
+                label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'ip'),
+                merged_dir=c.merged_dir,
             ),
         control=lambda wc:
             expand(
-	        c.patterns['merged_techreps'],
-	        label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'control'),
-	        merged_dir=c.merged_dir,
-	    ),
+                c.patterns['merged_techreps'],
+                label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'control'),
+                merged_dir=c.merged_dir,
+            ),
     output:
         bed=c.patterns['peaks']['sicer']
     log:

--- a/workflows/chipseq/config/chipseq_patterns.yaml
+++ b/workflows/chipseq/config/chipseq_patterns.yaml
@@ -45,6 +45,8 @@ patterns_by_peaks:
     peaks:
        macs2: '{peak_calling}/macs2/{macs2_run}/peaks.bed'
        spp: '{peak_calling}/spp/{spp_run}/peaks.bed'
+       sicer: '{peak_calling}/sicer/{sicer_run}/peaks.bed'
     bigbed:
         macs2: '{peak_calling}/macs2/{macs2_run}/peaks.bigbed'
         spp: '{peak_calling}/spp/{spp_run}/peaks.bigbed'
+        sicer: '{peak_calling}/sicer/{sicer_run}/peaks.bigbed'

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -58,10 +58,10 @@ chipseq:
       redundancy_threshold: 1
       window_size: 200
       fragment_size: 150
-###optional user-specified override mappable genome proportion
-###if specified here, SICER will use this value instead of the value specific to the genome build
-###if NOT specified here, SICER will use the mappability value for your genome build
-#     effective_genome_fraction: 0.75
+  # optional user-specified override mappable genome proportion
+  # if specified here, SICER will use this value instead of the value specific to the genome build
+  # if NOT specified here, SICER will use the mappability value for your genome build
+  #   effective_genome_fraction: 0.75
       gap_size: 600
       fdr: 0.01
       
@@ -73,9 +73,9 @@ chipseq:
         - gaf-embryo-1
       control:
         - input-embryo-1
-###optional user-specified override mappable genome size
-###if specified here, MACS will use this value instead of the value specific to the genome build
-###if NOT specified here, MACS will use the mappability value for your genome build
+  # optional user-specified override mappable genome size
+  # if specified here, MACS will use this value instead of the value specific to the genome build
+  # if NOT specified here, MACS will use the mappability value for your genome build
       effective_genome_count: 7e7
       extra: '--nomodel --extsize 147'
 
@@ -138,7 +138,7 @@ references:
     test:
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
       genome_build: dm6
@@ -151,9 +151,10 @@ references:
         indexes:
           - 'bowtie2'
 
-#these are pulled from various sources, most notably https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
-#these should only be considered approximate. more precise estimates can be generated with specific parameters from
-#individual experiments.
+# these are pulled from various sources, most notably
+#   https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
+# these should only be considered approximate. more precise estimates can be generated
+# with specific parameters from individual experiments.
 mappability:
   dm2:
     count: 1.2e8

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -67,56 +67,56 @@ chipseq:
       
 
 
-    - label: gaf-embryo-1
-      algorithm: macs2
-      ip:
-        - gaf-embryo-1
-      control:
-        - input-embryo-1
+#    - label: gaf-embryo-1
+#      algorithm: macs2
+#      ip:
+#        - gaf-embryo-1
+#      control:
+#        - input-embryo-1
   # optional user-specified override mappable genome size
   # if specified here, MACS will use this value instead of the value specific to the genome build
   # if NOT specified here, MACS will use the mappability value for your genome build
-      effective_genome_count: 7e7
-      extra: '--nomodel --extsize 147'
+#      effective_genome_count: 7e7
+#      extra: '--nomodel --extsize 147'
 
-    - label: gaf-embryo-1
-      algorithm: spp
-      ip:
-        - gaf-embryo-1
-      control:
-        - input-embryo-1
-      extra:
-        fdr: 0.3
-        zthr: 4
+#    - label: gaf-embryo-1
+#      algorithm: spp
+#      ip:
+#        - gaf-embryo-1
+#      control:
+#        - input-embryo-1
+#      extra:
+#        fdr: 0.3
+#        zthr: 4
 
-    - label: gaf-embryo-1-defaults
-      algorithm: spp
-      ip:
-        - gaf-embryo-1
-      control:
-        - input-embryo-1
+#    - label: gaf-embryo-1-defaults
+#      algorithm: spp
+#      ip:
+#        - gaf-embryo-1
+#      control:
+#        - input-embryo-1
+#
+#    - label: gaf-wingdisc-pooled
+#      algorithm: macs2
+#      ip:
+#        - gaf-wingdisc-1
+#        - gaf-wingdisc-2
+#      control:
+#        - input-wingdisc-1
+#        - input-wingdisc-2
+#      extra: '--nomodel --extsize 147'
 
-    - label: gaf-wingdisc-pooled
-      algorithm: macs2
-      ip:
-        - gaf-wingdisc-1
-        - gaf-wingdisc-2
-      control:
-        - input-wingdisc-1
-        - input-wingdisc-2
-      extra: '--nomodel --extsize 147'
-
-    - label: gaf-wingdisc-pooled
-      algorithm: spp
-      ip:
-        - gaf-wingdisc-1
-        - gaf-wingdisc-2
-      control:
-        - input-wingdisc-1
+#    - label: gaf-wingdisc-pooled
+#      algorithm: spp
+#      ip:
+#        - gaf-wingdisc-1
+#        - gaf-wingdisc-2
+#      control:
+#        - input-wingdisc-1
         # - input-wingdisc-2
-      extra:
-        fdr: 0.5
-        zthr: 4
+#      extra:
+#        fdr: 0.5
+#        zthr: 4
 
 
 aligner:

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -49,12 +49,34 @@ chipseq:
   # at least a BED file of peaks.
   #
   peak_calling:
+    - label: gaf-embryo-sicer
+      algorithm: sicer
+      ip:
+        - gaf-embryo-1
+      control:
+        - input-embryo-1
+      redundancy_threshold: 1
+      window_size: 200
+      fragment_size: 150
+###optional user-specified override mappable genome proportion
+###if specified here, SICER will use this value instead of the value specific to the genome build
+###if NOT specified here, SICER will use the mappability value for your genome build
+#     effective_genome_fraction: 0.75
+      gap_size: 600
+      fdr: 0.01
+      
+
+
     - label: gaf-embryo-1
       algorithm: macs2
       ip:
         - gaf-embryo-1
       control:
         - input-embryo-1
+###optional user-specified override mappable genome size
+###if specified here, MACS will use this value instead of the value specific to the genome build
+###if NOT specified here, MACS will use the mappability value for your genome build
+      effective_genome_count: 7e7
       extra: '--nomodel --extsize 147'
 
     - label: gaf-embryo-1
@@ -116,9 +138,11 @@ references:
     test:
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.common.gzipped'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
         indexes:
           - 'bowtie2'
+      genome_build: dm6
+
   phix:
     default:
       fasta:
@@ -126,3 +150,59 @@ references:
         postprocess: "lib.postprocess.phix.fasta_postprocess"
         indexes:
           - 'bowtie2'
+
+#these are pulled from various sources, most notably https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
+#these should only be considered approximate. more precise estimates can be generated with specific parameters from
+#individual experiments.
+mappability:
+  dm2:
+    count: 1.2e8
+    proportion: 0.88
+  dm3:
+    count: 1.2e8
+    proportion: 0.88
+  dm6:
+    count: 1.2e8
+    proportion: 0.88
+  hg18:
+    count: 2.7e9
+    proportion: 0.87
+  hg19:
+    count: 2.7e9
+    proportion: 0.87
+  hg38:
+    count: 2.7e9
+    proportion: 0.87
+  mm8:
+    count: 2.3e9
+    proportion: 0.87
+  mm9:
+    count: 2.3e9
+    proportion: 0.87
+  mm10:
+    count: 2.3e9
+    proportion: 0.87
+  rn4:
+    count: 2.2e9
+    proportion: 0.80
+  rn5:
+    count: 2.2e9
+    proportion: 0.76
+  rn6:
+    count: 2.2e9
+    proportion: 0.82
+  sacCer1:
+    count: 1.2e7
+    proportion: 0.95
+  sacCer2:
+    count: 1.2e7
+    proportion: 0.95
+  sacCer3:
+    count: 1.2e7
+    proportion: 0.95
+  pombe:
+    count: 1.2e7
+    proportion: 0.97
+  tair8:
+    count: 1.1e8
+    proportion: 0.95

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -67,56 +67,56 @@ chipseq:
       
 
 
-#    - label: gaf-embryo-1
-#      algorithm: macs2
-#      ip:
-#        - gaf-embryo-1
-#      control:
-#        - input-embryo-1
+    - label: gaf-embryo-1
+      algorithm: macs2
+      ip:
+        - gaf-embryo-1
+      control:
+        - input-embryo-1
   # optional user-specified override mappable genome size
   # if specified here, MACS will use this value instead of the value specific to the genome build
   # if NOT specified here, MACS will use the mappability value for your genome build
-#      effective_genome_count: 7e7
-#      extra: '--nomodel --extsize 147'
+      effective_genome_count: 7e7
+      extra: '--nomodel --extsize 147'
 
-#    - label: gaf-embryo-1
-#      algorithm: spp
-#      ip:
-#        - gaf-embryo-1
-#      control:
-#        - input-embryo-1
-#      extra:
-#        fdr: 0.3
-#        zthr: 4
+    - label: gaf-embryo-1
+      algorithm: spp
+      ip:
+        - gaf-embryo-1
+      control:
+        - input-embryo-1
+      extra:
+        fdr: 0.3
+        zthr: 4
 
-#    - label: gaf-embryo-1-defaults
-#      algorithm: spp
-#      ip:
-#        - gaf-embryo-1
-#      control:
-#        - input-embryo-1
-#
-#    - label: gaf-wingdisc-pooled
-#      algorithm: macs2
-#      ip:
-#        - gaf-wingdisc-1
-#        - gaf-wingdisc-2
-#      control:
-#        - input-wingdisc-1
-#        - input-wingdisc-2
-#      extra: '--nomodel --extsize 147'
+    - label: gaf-embryo-1-defaults
+      algorithm: spp
+      ip:
+        - gaf-embryo-1
+      control:
+        - input-embryo-1
 
-#    - label: gaf-wingdisc-pooled
-#      algorithm: spp
-#      ip:
-#        - gaf-wingdisc-1
-#        - gaf-wingdisc-2
-#      control:
-#        - input-wingdisc-1
+    - label: gaf-wingdisc-pooled
+      algorithm: macs2
+      ip:
+        - gaf-wingdisc-1
+        - gaf-wingdisc-2
+      control:
+        - input-wingdisc-1
+        - input-wingdisc-2
+      extra: '--nomodel --extsize 147'
+
+    - label: gaf-wingdisc-pooled
+      algorithm: spp
+      ip:
+        - gaf-wingdisc-1
+        - gaf-wingdisc-2
+      control:
+        - input-wingdisc-1
         # - input-wingdisc-2
-#      extra:
-#        fdr: 0.5
-#        zthr: 4
+      extra:
+        fdr: 0.5
+        zthr: 4
 
 
 aligner:

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,7 +82,7 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,7 +82,7 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.common.gzipped'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/wrappers/wrappers/macs2/callpeak/wrapper.py
+++ b/wrappers/wrappers/macs2/callpeak/wrapper.py
@@ -10,6 +10,13 @@ outdir, basebed = os.path.split(snakemake.output.bed)
 label = snakemake.params.block['label']
 extra = snakemake.params.block.get('extra', '')
 
+effective_genome_count = snakemake.params.block.get('effective_genome_count',
+                                                    snakemake.params.block.get('reference_effective_genome_count', ''))
+
+genome_count_flag = ''
+if effective_genome_count != '':
+    genome_count_flag = ' -g ' + effective_genome_count + ' '
+
 cmds = (
     'macs2 '
     'callpeak '
@@ -17,7 +24,7 @@ cmds = (
     '-t {snakemake.input.ip} '
     '-f BAM '
     '--outdir {outdir} '
-    '--name {label} '
+    '--name {label} ' + genome_count_flag
 )
 # add any per-peak-calling-run extra commands
 cmds += extra

--- a/wrappers/wrappers/sicer/README.md
+++ b/wrappers/wrappers/sicer/README.md
@@ -56,4 +56,4 @@ by downstream rules, however the wrapper only pays attention to
 
 
 ## Params
-DO NOT USE `extra` FOR THIS RULE. SICER IS A JERK ABOUT PARAMETERS. USE THE NAMED PARAMETERS ABOVE.
+Do not use `extra` for this rule.

--- a/wrappers/wrappers/sicer/README.md
+++ b/wrappers/wrappers/sicer/README.md
@@ -1,0 +1,59 @@
+# SICER
+
+Wraps the `sicer` program to call ChIP-seq peaks on input BED files.
+
+## Examples
+
+Minimal usage. SICER is the best operating piece of hot garbage you'll ever find.
+It has a completely fixed set of input parameters it requires, hard-coded genome
+data in SICER/lib/GenomeData.py (submit bug report in bioconda if you need
+additions), and it can't be run from the same directory at the same time due to
+hard coded output filenames. It's a proper mess boss.
+
+```python
+rule sicer:
+    input:
+        ip='ip.bed',
+        control='input.bed',
+	redundancy_threshold=1,
+	window_size=200,
+	fragment_size=150,
+	effective_genome_fraction=0.75,
+	gap_size=600,
+	fdr=0.01
+    output:
+        bed='out/peaks.bed'
+    wrapper:
+        'file://path/to/wrapper'
+```
+
+
+## Input
+
+`ip`: single BED for IP
+
+`control`: single BED for input
+
+`redundancy_threshold`: cutoff count above which duplicates are removed
+
+`window_size`: SICER resolution; 200 recommended for histones
+
+`fragment_size`: twice the shift from the beginning to the center of a read
+
+`effective_genome_fraction`: percentage of mappable genome; only set it here if you want to override the genome build in config.yaml
+
+`gap_size`: nonnegative integer multiple of window size. used to merge contiguous regions (higher means more liberal merging).
+
+`fdr`: FDR cutoff for calling significant regions.
+
+## Output
+
+`bed`: BED file of called peaks. This is a delicately processed version of `*island.bed` from SICER.
+
+Other files are created, these can be added as additional named outputs for use
+by downstream rules, however the wrapper only pays attention to
+`snakemake.output.bed`.
+
+
+## Params
+DO NOT USE `extra` FOR THIS RULE. SICER IS A JERK ABOUT PARAMETERS. USE THE NAMED PARAMETERS ABOVE.

--- a/wrappers/wrappers/sicer/environment.yaml
+++ b/wrappers/wrappers/sicer/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python=2
   - sicer
   - bedtools
   - ucsc-bedsort

--- a/wrappers/wrappers/sicer/environment.yaml
+++ b/wrappers/wrappers/sicer/environment.yaml
@@ -1,0 +1,8 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - sicer
+  - bedtools
+  - ucsc-bedsort

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -41,7 +41,7 @@ shell(
 
 shell(
     """cd {tmpdir} && """
-    """function python {{ $CONDA_PREFIX/bin/python2.7 "$@" ; }} && """
+    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/' $CONDA_PREFIX/share/sicer*/SICER.sh ; fi ; }} && fixci && """
     """SICER.sh {tmpdir} ip.bed in.bed {tmpdir} """
     """{genome_build} {redundancy_threshold} {window_size} """
     """{fragment_size} {effective_genome_fraction} {gap_size} {fdr} && """

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -3,15 +3,30 @@ import os
 import glob
 from snakemake import shell
 
-log = snakemake.log_fmt_shell()
 logfile = None
-redundancy_threshold = snakemake.params.block.get('redundancy_threshold', snakemake.params.get('redundancy_threshold'))
-window_size = snakemake.params.block.get('window_size', snakemake.params.get('redundancy_threshold'))
-fragment_size = snakemake.params.block.get('fragment_size', snakemake.params.get('fragment_size'))
-effective_genome_fraction = snakemake.params.block.get('effective_genome_fraction', snakemake.params.block.get('reference_effective_genome_fraction'))
-gap_size = snakemake.params.block.get('gap_size', snakemake.params.get('gap_size'))
-fdr = snakemake.params.block.get('fdr', snakemake.params.get('fdr'))
-genome_build = snakemake.params.block.get('genome_build', snakemake.params.block.get('reference_genome_build'))
+
+# as SICER's interface is rather strict, this wrapper enforces named variables instead of 'extra' arbitrary string
+
+redundancy_threshold = snakemake.params.block.get('redundancy_threshold',
+                                                  snakemake.params.get('redundancy_threshold'))
+
+window_size = snakemake.params.block.get('window_size',
+                                         snakemake.params.get('redundancy_threshold'))
+
+fragment_size = snakemake.params.block.get('fragment_size',
+                                           snakemake.params.get('fragment_size'))
+
+effective_genome_fraction = snakemake.params.block.get('effective_genome_fraction',
+                                                       snakemake.params.block.get('reference_effective_genome_fraction'))
+
+gap_size = snakemake.params.block.get('gap_size',
+                                      snakemake.params.get('gap_size'))
+
+fdr = snakemake.params.block.get('fdr',
+                                 snakemake.params.get('fdr'))
+
+genome_build = snakemake.params.block.get('genome_build',
+                                          snakemake.params.block.get('reference_genome_build'))
 
 if redundancy_threshold is None:
     raise ValueError("SICER requires the specification of a 'redundancy_threshold'")
@@ -34,20 +49,35 @@ label = snakemake.params.block['label']
 tmpdir = tempfile.mkdtemp()
 cwd = os.getcwd()
 
+# SICER expects bed input format, not bam as in other peak callers
 shell(
     'bamToBed -i {snakemake.input.ip} > {tmpdir}/ip.bed ; '
     'bamToBed -i {snakemake.input.control} > {tmpdir}/in.bed '
 )
 
+# SICER emits a single hard-coded file that does not respect output directory.
+# So move each run into its own temp directory to avoid collisions with
+# other processes.
+os.chdir(tmpdir)
+
 shell(
-    """cd {tmpdir} && """
-    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/' $CONDA_PREFIX/share/sicer*/SICER.sh ; fi ; }} && fixci && """
+    # there is a CI-specific bug, in which the python symlink is not correctly resolved to python2.7;
+    # so as a really desperate hack, modify SICER's python calls to directly touch 2.7
+    # but only on circleci
+    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/'"""
+    """$CONDA_PREFIX/share/sicer*/SICER.sh ; fi ; }} && fixci"""
+)
+shell(
+    # run SICER
     """SICER.sh {tmpdir} ip.bed in.bed {tmpdir} """
     """{genome_build} {redundancy_threshold} {window_size} """
-    """{fragment_size} {effective_genome_fraction} {gap_size} {fdr} && """
-    """cd {cwd}"""
+    """{fragment_size} {effective_genome_fraction} {gap_size} {fdr} > tmp.output 2>&1 """
 )
 
+# Move back once the run is complete.
+os.chdir(cwd)
+
+# one of the results files gets converted to the broadPeak format ala macs
 resultsfile = glob.glob(os.path.join(tmpdir, '*-islands-summary-FDR*'))
 if len(resultsfile) == 1:
     hit = resultsfile[0]
@@ -57,60 +87,66 @@ elif len(resultsfile) > 1:
 else:
     raise ValueError("No islands-summary-FDR file found: " + str(os.listdir(tmpdir)))
 
+# "summary graph for [the run] in bedGraph format"
 summary_graph = glob.glob(os.path.join(tmpdir, '*-W{0}.graph*'.format(window_size)))
 if len(summary_graph) == 1:
     summary_graph = summary_graph[0]
 else:
     raise ValueError("SICER graph output file not found")
 
+# the bedGraph file above, normalized by library size per million, in wig format
 normalized_prefilter_wig = glob.glob(os.path.join(tmpdir, '*-W{0}-normalized.wig'.format(window_size)))
 if len(normalized_prefilter_wig) == 1:
     normalized_prefilter_wig = normalized_prefilter_wig[0]
 else:
     raise ValueError("SICER normalized prefilter wig file not found")
 
+# "summary of all candidate islands with their statistical significance
 candidate_islands = glob.glob(os.path.join(tmpdir, '*-W{0}-G{1}-islands-summary'.format(window_size, gap_size)))
 if len(candidate_islands) == 1:
     candidate_islands = candidate_islands[0]
 else:
     raise ValueError("SICER candidate islands file not found")
 
+# "delineation of significant islands"
 significant_islands = glob.glob(os.path.join(tmpdir, '*-W{0}-G{1}-FDR*-island.bed'.format(window_size, gap_size)))
 if len(significant_islands) == 1:
     significant_islands = significant_islands[0]
 else:
     raise ValueError("SICER significant islands file not found")
 
+# "library of raw redundancy-removed reads on significant islands
 redundancy_removed = glob.glob(os.path.join(tmpdir, '*-W{0}-G{1}-FDR*-islandfiltered.bed'.format(window_size, gap_size)))
 if len(redundancy_removed) == 1:
     redundancy_removed = redundancy_removed[0]
 else:
     raise ValueError("SICER redundancy removed library file not found")
 
+# "wig file for the island-filtered redundancy-removed reads
 normalized_postfilter_wig = glob.glob(os.path.join(tmpdir, '*-W{0}-G{1}-FDR*-islandfiltered-normalized.wig'.format(window_size, gap_size)))
 if len(normalized_postfilter_wig) == 1:
     normalized_postfilter_wig = normalized_postfilter_wig[0]
 else:
     raise ValueError("SICER normalized postfilter wig file not found")
 
-
-# Fix the output file so that it conforms to UCSC guidelines
-#shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
-#shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
-
 shell(
     "export LC_COLLATE=C; "
+    # format the output in broadPeak format
     """awk -F"\\t" -v lab={label} """
     """'{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, """
     """$2, $3-1, lab, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """
     "{hit} > {snakemake.output.bed}.tmp && "
+    # sort the bed file, just to be sure
     "bedSort {snakemake.output.bed}.tmp {snakemake.output.bed} && "
-    "cp {resultsfile} {snakemake.output.bed}-islands-summary-significant && "
-    "cp {summary_graph} {snakemake.output.bed}.graph && "
-    "cp {normalized_prefilter_wig} {snakemake.output.bed}-normalized-prefilter.wig && "
-    "cp {normalized_postfilter_wig} {snakemake.output.bed}-normalized-postfilter.wig && "
-    "cp {candidate_islands} {snakemake.output.bed}-islands-summary && "
-    "cp {significant_islands} {snakemake.output.bed}-island.bed && "
-    "cp {redundancy_removed} {snakemake.output.bed}-islandfiltered.bed && "
+    # rename the assorted output files
+    "mv {resultsfile} {snakemake.output.bed}-islands-summary-significant && "
+    "mv {summary_graph} {snakemake.output.bed}.graph && "
+    "mv {normalized_prefilter_wig} {snakemake.output.bed}-normalized-prefilter.wig && "
+    "mv {normalized_postfilter_wig} {snakemake.output.bed}-normalized-postfilter.wig && "
+    "mv {candidate_islands} {snakemake.output.bed}-islands-summary && "
+    "mv {significant_islands} {snakemake.output.bed}-island.bed && "
+    "mv {redundancy_removed} {snakemake.output.bed}-islandfiltered.bed && "
+    "mv {tmpdir}/tmp.output {snakemake.output.bed}.log && "
+    # clean up the temp directory
     "rm {snakemake.output.bed}.tmp && rm -Rf {tmpdir}"
 )

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -34,6 +34,7 @@ label = snakemake.params.block['label']
 tmpdir = tempfile.mkdtemp()
 cwd = os.getcwd()
 
+
 shell(
     'bamToBed -i {snakemake.input.ip} > {tmpdir}/ip.bed ; '
     'bamToBed -i {snakemake.input.control} > {tmpdir}/in.bed '
@@ -41,10 +42,10 @@ shell(
 
 shell(
     """cd {tmpdir} && """
-    """whereis SICER | sed "s/\\/bin\\/SICER.sh/\\/share\\/sicer*\\/SICER.sh/g" | """
-    """awk '{{printf("%s ", $2)}}' > run_command.bash && """
+    """awk '{{printf("$CONDA_PREFIX/share/sicer*/SICER.sh ", $2)}}' > run_command.bash && """
     """echo "{tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} """
     """{fragment_size} {effective_genome_fraction} {gap_size} {fdr}" >> run_command.bash && """
+    """cat run_command.bash && """
     """bash run_command.bash """
     """&& cd {cwd}"""
 )

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -44,8 +44,8 @@ shell(cmds)
 cmds = (
     'cd {tmpdir} && '
     'SICER.sh {tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} {fragment_size} {effective_genome_fraction} {gap_size} {fdr} '
-    ' > tmp.sicer.output 2> tmp.sicer.error && '
-    'cd {cwd}'
+#    ' > tmp.sicer.output 2> tmp.sicer.error '
+    '&& cd {cwd}'
 )
 
 shell(cmds)
@@ -61,8 +61,8 @@ else:
     raise ValueError("No islands-summary-FDR file found: " + str(os.listdir(tmpdir)))
 
 # Fix the output file so that it conforms to UCSC guidelines
-shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
-shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
+#shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
+#shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
 
 shell(
     "export LC_COLLATE=C; "

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -42,8 +42,8 @@ shell(
 
 shell(
     """cd {tmpdir} && """
-    """awk '{{printf("$CONDA_PREFIX/share/sicer*/SICER.sh ", $2)}}' > run_command.bash && """
-    """echo "{tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} """
+    """echo "$CONDA_PREFIX/share/sicer*/SICER.sh {tmpdir} ip.bed in.bed {tmpdir} """
+    """{genome_build} {redundancy_threshold} {window_size} """
     """{fragment_size} {effective_genome_fraction} {gap_size} {fdr}" >> run_command.bash && """
     """cat run_command.bash && """
     """bash run_command.bash """

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -41,6 +41,10 @@ shell(
 shell(
     'cd {tmpdir} && '
 
+    # locally this seems fine; circleci somehow is getting py3?
+    'which python && '
+    'python -c "import sys; print(sys.version)" && '
+
     'SICER.sh {tmpdir} ip.bed in.bed '
     '{tmpdir} {genome_build} {redundancy_threshold} {window_size} '
     '{fragment_size} {effective_genome_fraction} {gap_size} {fdr} '

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -45,6 +45,8 @@ shell(
     'which python && '
     'python -c "import sys; print(sys.version)" && '
 
+    'echo $PATH && '
+
     'SICER.sh {tmpdir} ip.bed in.bed '
     '{tmpdir} {genome_build} {redundancy_threshold} {window_size} '
     '{fragment_size} {effective_genome_fraction} {gap_size} {fdr} '

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -64,7 +64,7 @@ shell(
     # there is a CI-specific bug, in which the python symlink is not correctly resolved to python2.7;
     # so as a really desperate hack, modify SICER's python calls to directly touch 2.7
     # but only on circleci
-    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/'"""
+    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/' """
     """$CONDA_PREFIX/share/sicer*/SICER.sh ; fi ; }} && fixci"""
 )
 shell(

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -56,9 +56,9 @@ if len(resultsfile) == 1:
     hit = resultsfile[0]
     basehit = os.path.basename(resultsfile[0])
 elif len(resultsfile) > 1:
-    raise ValueError("Multiple islands-summary-FDR files found in temporary working directory: " + os.listdir(tmpdir))
+    raise ValueError("Multiple islands-summary-FDR files found in temporary working directory: " + str(os.listdir(tmpdir)))
 else:
-    raise ValueError("No islands-summary-FDR file found: " + os.listdir(tmpdir))
+    raise ValueError("No islands-summary-FDR file found: " + str(os.listdir(tmpdir)))
 
 # Fix the output file so that it conforms to UCSC guidelines
 shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -32,6 +32,7 @@ outdir, basebed = os.path.split(snakemake.output.bed)
 label = snakemake.params.block['label']
 
 tmpdir = tempfile.mkdtemp()
+cwd = os.getcwd()
 
 shell(
     'bamToBed -i {snakemake.input.ip} > {tmpdir}/ip.bed ; '

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -39,17 +39,13 @@ shell(
 )
 
 shell(
-    'cd {tmpdir} && '
-
-    # locally this seems fine; circleci somehow is getting py3?
-    'which python && '
-    'python -c "import sys; print(sys.version)" && '
-
-    'echo $PATH && '
-
-    'SICER.sh {tmpdir} ip.bed in.bed '
-    '{tmpdir} {genome_build} {redundancy_threshold} {window_size} '
-    '{fragment_size} {effective_genome_fraction} {gap_size} {fdr} '
+    """cd {tmpdir} && """
+    """whereis SICER | sed "s/\\/bin\\/SICER.sh/\\/share\\/sicer*\\/SICER.sh/g" | """
+    """awk '{{printf("%s ", $2)}}' > run_command.bash && """
+    """echo "{tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} """
+    """{fragment_size} {effective_genome_fraction} {gap_size} {fdr}" >> run_command.bash && """
+    """bash run_command.bash """
+    """&& cd {cwd}"""
 )
 
 resultsfile = glob.glob(os.path.join(tmpdir, '*-islands-summary-FDR*'))

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -56,9 +56,9 @@ if len(resultsfile) == 1:
     hit = resultsfile[0]
     basehit = os.path.basename(resultsfile[0])
 elif len(resultsfile) > 1:
-    raise ValueError("Multiple islands-summary-FDR files found in temporary working directory")
+    raise ValueError("Multiple islands-summary-FDR files found in temporary working directory: " + os.listdir(tmpdir))
 else:
-    raise ValueError("No islands-summary-FDR file found!")
+    raise ValueError("No islands-summary-FDR file found: " + os.listdir(tmpdir))
 
 # Fix the output file so that it conforms to UCSC guidelines
 shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
@@ -66,7 +66,7 @@ shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
 
 shell(
     "export LC_COLLATE=C; "
-    """awk -F"\\t" '{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, $2, $3-1, {label}, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """
+    """awk -F"\\t" -v lab={label} '{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, $2, $3-1, lab, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """
     "{hit} > {snakemake.output.bed}.tmp "
     "&& bedSort {snakemake.output.bed}.tmp {snakemake.output.bed}"
     "&& rm {snakemake.output.bed}.tmp && rm -Rf {tmpdir}"

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -1,0 +1,72 @@
+import tempfile
+import os
+import glob
+from snakemake import shell
+
+log = snakemake.log_fmt_shell()
+logfile = None
+redundancy_threshold = snakemake.params.block.get('redundancy_threshold', snakemake.params.get('redundancy_threshold', ''))
+window_size = snakemake.params.block.get('window_size', snakemake.params.get('redundancy_threshold', ''))
+fragment_size = snakemake.params.block.get('fragment_size', snakemake.params.get('fragment_size', ''))
+effective_genome_fraction = snakemake.params.block.get('effective_genome_fraction', snakemake.params.block.get('reference_effective_genome_fraction', ''))
+gap_size = snakemake.params.block.get('gap_size', snakemake.params.get('gap_size', ''))
+fdr = snakemake.params.block.get('fdr', snakemake.params.get('fdr', ''))
+genome_build = snakemake.params.block.get('genome_build', snakemake.params.block.get('reference_genome_build', ''))
+
+if redundancy_threshold == '':
+    raise ValueError("SICER requires the specification of a 'redundancy_threshold'")
+if window_size == '':
+    raise ValueError("SICER requires the specification of a 'window_size'")
+if fragment_size == '':
+    raise ValueError("SICER requires the specification of a 'fragment_size'")
+if effective_genome_fraction == '':
+    raise ValueError("SICER requires the specification of an 'effective_genome_fraction'")
+if gap_size == '':
+    raise ValueError("SICER requires the specification of a 'gap_size'")
+if fdr == '':
+    raise ValueError("SICER requires the specification of an 'fdr'")
+if genome_build == '':
+    raise ValueError("SICER requires the specification of a recognized genome build")
+
+outdir, basebed = os.path.split(snakemake.output.bed)
+label = snakemake.params.block['label']
+
+tmpdir = tempfile.mkdtemp()
+cwd = os.getcwd()
+
+cmds = (
+    'bamToBed -i {snakemake.input.ip} > {tmpdir}/ip.bed ; '
+    'bamToBed -i {snakemake.input.control} > {tmpdir}/in.bed '
+)
+
+shell(cmds)
+
+os.chdir(tmpdir)
+
+cmds = (
+    'SICER.sh {tmpdir} ip.bed in.bed {tmpdir} {genome_build} {redundancy_threshold} {window_size} {fragment_size} {effective_genome_fraction} {gap_size} {fdr}'
+)
+
+shell(cmds + ' > tmp.sicer.output 2> tmp.sicer.error')
+
+resultsfile = glob.glob(os.path.join(tmpdir, '*-islands-summary-FDR*'))
+
+if len(resultsfile) == 1:
+    hit = resultsfile[0]
+    basehit = os.path.basename(resultsfile[0])
+else:
+    raise ValueError("No islands-summary-FDR file found!")
+
+os.chdir(cwd)
+
+# Fix the output file so that it conforms to UCSC guidelines
+shell("mv {tmpdir}/tmp.sicer.output {snakemake.output.bed}.sicer.output")
+shell("mv {tmpdir}/tmp.sicer.error {snakemake.output.bed}.sicer.error")
+
+shell(
+    "export LC_COLLATE=C; "
+    """awk -F"\\t" '{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, $2, $3-1, {label}, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """
+    "{hit} > {snakemake.output.bed}.tmp "
+    "&& bedSort {snakemake.output.bed}.tmp {snakemake.output.bed}"
+    "&& rm {snakemake.output.bed}.tmp && rm -Rf {tmpdir}"
+)


### PR DESCRIPTION
Candidate code for SICER integration into ChIP-seq pipeline. Features:

-SICER runs now supported in ChIP-seq using similar method as with MACS2 and spp. 

-mappable genome proportion or count is now available to peak callers in each run block by injection from the config file.

-SICER and macs2 wrappers both intercept user-specified or genome-default mappable genome information and specify it to the program call.