### PR TITLE
Cleaner FlyBase chr processing; attempt at fixing SICER ci failure

### DIFF
--- a/lib/postprocess/dm6.py
+++ b/lib/postprocess/dm6.py
@@ -1,13 +1,8 @@
 from snakemake.shell import shell
 
-def fasta_postprocess_nogzip(origfn, newfn):
-    shell(
-        "cat {origfn} | chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
-        "| gzip -c > {newfn} && rm {origfn}")
-
 def fasta_postprocess(origfn, newfn):
     shell(
-          "gunzip -c {origfn} "
+          "gunzip -fc {origfn} "
           "| chrom_convert --from FlyBase --to UCSC --fileType FASTA -i - "
           "| gzip -c > {newfn} "
           "&& rm {origfn}")

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -58,10 +58,10 @@ chipseq:
       redundancy_threshold: 1
       window_size: 200
       fragment_size: 150
-###optional user-specified override mappable genome proportion
-###if specified here, SICER will use this value instead of the value specific to the genome build
-###if NOT specified here, SICER will use the mappability value for your genome build
-#     effective_genome_fraction: 0.75
+  # optional user-specified override mappable genome proportion
+  # if specified here, SICER will use this value instead of the value specific to the genome build
+  # if NOT specified here, SICER will use the mappability value for your genome build
+  #   effective_genome_fraction: 0.75
       gap_size: 600
       fdr: 0.01
       
@@ -73,9 +73,9 @@ chipseq:
         - gaf-embryo-1
       control:
         - input-embryo-1
-###optional user-specified override mappable genome size
-###if specified here, MACS will use this value instead of the value specific to the genome build
-###if NOT specified here, MACS will use the mappability value for your genome build
+  # optional user-specified override mappable genome size
+  # if specified here, MACS will use this value instead of the value specific to the genome build
+  # if NOT specified here, MACS will use the mappability value for your genome build
       effective_genome_count: 7e7
       extra: '--nomodel --extsize 147'
 
@@ -138,7 +138,7 @@ references:
     test:
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
       genome_build: dm6
@@ -151,9 +151,10 @@ references:
         indexes:
           - 'bowtie2'
 
-#these are pulled from various sources, most notably https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
-#these should only be considered approximate. more precise estimates can be generated with specific parameters from
-#individual experiments.
+# these are pulled from various sources, most notably
+#   https://github.com/biocore-ntnu/epic/tree/master/epic/scripts/effective_sizes
+# these should only be considered approximate. more precise estimates can be generated
+# with specific parameters from individual experiments.
 mappability:
   dm2:
     count: 1.2e8

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,7 +82,7 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess_nogzip'
+        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/wrappers/wrappers/sicer/README.md
+++ b/wrappers/wrappers/sicer/README.md
@@ -56,4 +56,4 @@ by downstream rules, however the wrapper only pays attention to
 
 
 ## Params
-DO NOT USE `extra` FOR THIS RULE. SICER IS A JERK ABOUT PARAMETERS. USE THE NAMED PARAMETERS ABOVE.
+Do not use `extra` for this rule.


### PR DESCRIPTION
First attempt at addressing comments raised by Ryan Dale. Handles reference data processing much more cleanly. Adapted several SICER wrapper modifications for legibility. Modified shell cd to tmpdir and call to protect against one possible runtime error.