### PR TITLE
Assorted modifications 16-20apr2018

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ workflows:
            branches:
              ignore:
                - master
-	       - sicer-integration
+               - sicer-integration
       - rnaseq:
           requires:
             - initial-setup
@@ -149,7 +149,7 @@ workflows:
             branches:
               ignore:
                 - master
-		- sicer-integration
+                - sicer-integration
       - references:
           requires:
             - initial-setup
@@ -157,4 +157,4 @@ workflows:
             branches:
               ignore:
                 - master
-		- sicer-integration
+                - sicer-integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ workflows:
            branches:
              ignore:
                - master
+	       - sicer-integration
       - rnaseq:
           requires:
             - initial-setup
@@ -148,6 +149,7 @@ workflows:
             branches:
               ignore:
                 - master
+		- sicer-integration
       - references:
           requires:
             - initial-setup
@@ -155,3 +157,4 @@ workflows:
             branches:
               ignore:
                 - master
+		- sicer-integration

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -310,7 +310,7 @@ rule markduplicates:
     log:
         c.patterns['markduplicates']['bam'] + '.log'
     params:
-        java_args='-Xmx32g'
+        java_args='-Xmx20g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'picard '
@@ -433,6 +433,7 @@ rule sicer:
                 label=chipseq.samples_for_run(config, wc.sicer_run, 'sicer', 'control'),
                 merged_dir=c.merged_dir,
             ),
+            chromsizes=refdict[c.assembly][config['aligner']['tag']]['chromsizes'],
     output:
         bed=c.patterns['peaks']['sicer']
     log:

--- a/workflows/chipseq/config/clusterconfig.yaml
+++ b/workflows/chipseq/config/clusterconfig.yaml
@@ -27,3 +27,6 @@ fingerprint:
 
 spp:
   prefix: "--gres=lscratch:20 --mem=16g --time=4:00:00"
+
+sicer:
+  prefix: "--gres=lscratch:20 --mem=16g --time=4:00:00"

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -155,7 +155,7 @@ format.group.name <- function(pattern.mat) {
 	    # if 1, include
 	    if (pattern.mat[i] == 1) my.res <- paste(my.res, names(pattern.mat[i]), sep=".")
 	    # otherwise don't
-	    else my.res <- paste(my.res, "not", names(pattern.mat[i]), sep=".")
+	    else my.res <- paste(my.res, ".not", names(pattern.mat[i]), sep="")
 	}
     }
     my.res

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -142,25 +142,23 @@ DESeqDataSetFromSalmon <- function (sampleTable, directory='.', design,
 #' @return formatted column name
 
 format.group.name <- function(pattern.mat) {
-    res <- ""
+    my.res <- "counts"
     # enforce input format
     stopifnot(is.vector(pattern.mat))
     # if there's only one element
-    if (length(pattern) == 1) {
+    if (length(pattern.mat) == 1) {
         # it must be the intercept
-	res <- "groupMean"
+	my.res <- paste(my.res, "groupMean", sep=".")
     } else { # more than one element
         # for every non-intercept entry
         for (i in 2:length(pattern.mat)) {
-	    # if it's not the first, add a delimiter
-	    if (i > 2) res <- paste(res, ".", sep="")
 	    # if 1, include
-	    if (pattern.mat[i] == 1) res <- paste(res, names(pattern.mat[i]), sep="")
+	    if (pattern.mat[i] == 1) my.res <- paste(my.res, names(pattern.mat[i]), sep=".")
 	    # otherwise don't
-	    else res <- paste(res, "not", names(pattern.mat[i]), sep="")
+	    else my.res <- paste(my.res, "not", names(pattern.mat[i]), sep=".")
 	}
     }
-    res
+    my.res
 }
 
 #' Plot a gene's normalized counts across samples

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -135,6 +135,34 @@ DESeqDataSetFromSalmon <- function (sampleTable, directory='.', design,
     return(object)
 }
 
+#' Compute label for one component of an arbitrary design matrix
+#'
+#' @param pattern.mat single row from unique(model.matrix) call from a dds object
+#'
+#' @return formatted column name
+
+format.group.name <- function(pattern.mat) {
+    res <- ""
+    # enforce input format
+    stopifnot(is.vector(pattern.mat))
+    # if there's only one element
+    if (length(pattern) == 1) {
+        # it must be the intercept
+	res <- "groupMean"
+    } else { # more than one element
+        # for every non-intercept entry
+        for (i in 2:length(pattern.mat)) {
+	    # if it's not the first, add a delimiter
+	    if (i > 2) res <- paste(res, ".", sep="")
+	    # if 1, include
+	    if (pattern.mat[i] == 1) res <- paste(res, names(pattern.mat[i]), sep="")
+	    # otherwise don't
+	    else res <- paste(res, "not", names(pattern.mat[i]), sep="")
+	}
+    }
+    res
+}
+
 #' Plot a gene's normalized counts across samples
 #'
 #' @param gene Gene ID

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -365,7 +365,7 @@ for (name in names(res.list)){
   mdcat('### Normalized counts of top 3 downregulated genes')
   top.plots(padj.order(res.i, reverse=TRUE), 3, my.counts, dds.i, add_cols)
   mdcat('### M-A plot')
-  DESeq2::plotMA(res.i)
+  plotMA(res.i)
   mdcat('### P-value distribution')
   pval.hist(res.i)
 }

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -148,6 +148,10 @@ dds.txi <- DESeqDataSetFromSalmon(
                                   design=~group)
 # rlog normalize transcript counts
 rld.txi <- varianceStabilizingTransformation(dds.txi, blind=FALSE)
+# extract count frame
+transcript.counts <- assay(rld.txi)
+# correct the sample IDs
+colnames(transcript.counts) <- colData$samplename
 ```
 
 
@@ -311,6 +315,14 @@ for (name in names(res.list)){
         keytype=keytype,
         columns=columns)
 }
+
+# Assumption: using ENSEMBLTRANS transcript IDs with Salmon
+#  honestly if you're using something else, you may just want to skip this step.
+# append gene mappings to transcript counts from Salmon
+transcript.geneids <- mapIds(orgdb,
+		             keys=rownames(transcript.counts),
+		             column=keytype,
+			     keytype='ENSEMBLTRANS')
 ```
 
 # Differential expression
@@ -439,22 +451,27 @@ for (name in names(ll)){
 
 ```{r groupcounts, cache=TRUE}
 counts.list <- list()
-# Use normalized counts to get per-level mean counts. Attach them to results
-# for each result. This does ~not~ assume any particular model.
+
+# compute aggregate (by gene) normalized transcript counts from Salmon
+transcript.counts <- aggregate(transcript.counts, list(transcript.geneids), sum)
+
+# Use normalized counts to get per-level mean counts. Attach Salmon aggregate
+# counts to each output file. This does ~not~ assume any particular model.
 for (name in names(res.list)) {
+    counts.list[[name]] <- res.list[[name]][,c(1:4,7)]
     # extract the dds object in use
     my.dds <- dds.list[[name]]
-    # get the normalized per-gene count data
+
+    # get the DESeq2 normalized per-gene count data
     my.normalized.counts <- counts(my.dds, TRUE)
-    # report per-sample counts to output files
-    # this is really a placeholder for better Salmon handling later
+    colnames(transcript.counts) <- c("Gene", colnames(my.normalized.counts))
+
+    # report per-sample Salmon counts to output files
+    merged.results <- merge(data.frame(res.list[[name]]), transcript.counts, by.x="gene", by.y="Gene", all.x=TRUE)
     for (colname in colnames(my.normalized.counts)) {
-        res.list[[name]][,colname] <- my.normalized.counts[,colname]
+        res.list[[name]][,colname] <- merged.results[,colname]
 	colnames(res.list[[name]])[ncol(res.list[[name]])] <- paste("normcount", colnames(res.list[[name]])[ncol(res.list[[name]])], sep=".")
     }
-
-    # for debugging purposes, I'll have each analysis emit a single counts file
-    # with group-level counts summaries.
 
     # extract the design matrix
     my.model <- model.matrix(design(my.dds), colData(my.dds))
@@ -466,7 +483,7 @@ for (name in names(res.list)) {
     	in.pattern <- apply(my.model, 1, function(row) {all(row == my.unique.patterns[i,])})
 	# get counts just in those samples
 	in.counts <- rowMeans(my.normalized.counts[,in.pattern])
-	counts.list[[name]] <- cbind(res.list[[name]][,1:4], in.counts)
+	counts.list[[name]] <- cbind(counts.list[[name]], in.counts)
 	colnames(counts.list[[name]])[ncol(counts.list[[name]])] <- format.group.name(my.unique.patterns[i,])
     }
 }

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -298,32 +298,6 @@ res.list.lookup <- list(
 ```
 
 
-```{r groupcounts, cache=TRUE}
-# Use normalized counts to get per-level mean counts. Attach them to results
-# for each result. This does ~not~ assume any particular model.
-for (name in names(res.list)) {
-    # extract the dds object in use
-    my.dds <- dds.list[[name]]
-    # get the normalized per-gene count data
-    my.counts <- counts(my.dds, TRUE)
-    # extract the design matrix
-    my.model <- model.matrix(design(my.dds), colData(my.dds))
-    # unique rows correspond to groups
-    my.unique.patterns <- unique(my.model)
-    # for each unique pattern
-    for (i in 1:nrow(my.unique.patterns)) {
-    	# determine which samples conform to that pattern
-    	in.pattern <- apply(my.model, 1, function(row) {all(row == my.unique.patterns[i,])})
-	# get counts just in those samples
-	in.counts <- rowSums(my.counts[,in.pattern])
-	res.list[[name]] <- cbind(res.list[[name]], in.counts)
-	colnames(res.list[[name]])[ncol(res.list[[name]])] <- format.group.name(my.unique.patterns[i,])
-    }
-}
-
-```
-
-
 ```{r attach, cache=TRUE, depends='results'}
 # Assumption: Original annotations use Ensembl IDs
 keytype <- 'ENSEMBL'
@@ -379,7 +353,7 @@ for (name in names(res.list)){
   mdcat('### Normalized counts of top 3 downregulated genes')
   top.plots(padj.order(res.i, reverse=TRUE), 3, my.counts, dds.i, add_cols)
   mdcat('### M-A plot')
-  plotMA(res.i)
+  DESeq2::plotMA(res.i)
   mdcat('### P-value distribution')
   pval.hist(res.i)
 }
@@ -463,6 +437,43 @@ for (name in names(ll)){
 }
 ```
 
+```{r groupcounts, cache=TRUE}
+counts.list <- list()
+# Use normalized counts to get per-level mean counts. Attach them to results
+# for each result. This does ~not~ assume any particular model.
+for (name in names(res.list)) {
+    # extract the dds object in use
+    my.dds <- dds.list[[name]]
+    # get the normalized per-gene count data
+    my.normalized.counts <- counts(my.dds, TRUE)
+    # report per-sample counts to output files
+    # this is really a placeholder for better Salmon handling later
+    for (colname in colnames(my.normalized.counts)) {
+        res.list[[name]][,colname] <- my.normalized.counts[,colname]
+	colnames(res.list[[name]])[ncol(res.list[[name]])] <- paste("normcount", colnames(res.list[[name]])[ncol(res.list[[name]])], sep=".")
+    }
+
+    # for debugging purposes, I'll have each analysis emit a single counts file
+    # with group-level counts summaries.
+
+    # extract the design matrix
+    my.model <- model.matrix(design(my.dds), colData(my.dds))
+    # unique rows correspond to groups
+    my.unique.patterns <- unique(my.model)
+    # for each unique pattern
+    for (i in 1:nrow(my.unique.patterns)) {
+    	# determine which samples conform to that pattern
+    	in.pattern <- apply(my.model, 1, function(row) {all(row == my.unique.patterns[i,])})
+	# get counts just in those samples
+	in.counts <- rowMeans(my.normalized.counts[,in.pattern])
+	counts.list[[name]] <- cbind(res.list[[name]][,1:4], in.counts)
+	colnames(counts.list[[name]])[ncol(counts.list[[name]])] <- format.group.name(my.unique.patterns[i,])
+    }
+}
+
+```
+
+
 # Exported results
 
 ```{r}
@@ -492,6 +503,7 @@ for (name in names(res.list)){
   mdcat('## ', res.list.lookup[[name]])
   fn <- paste0(name, '.tsv')
   write.table(res.list[[name]], file=fn, row.names=FALSE, sep='\t')
+  write.table(counts.list[[name]], file=paste(fn, ".counts", sep=""), row.names=FALSE, sep="\t")
   mdcat('- [', fn, '](', fn, '), results for ', res.list.lookup[[name]])
   for (sel in names(sel.list[[name]])){
     fn <- paste0(name, '.', sel, '.tsv')

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -253,7 +253,6 @@ dds <- DESeq(dds,
 ```
 
 
-
 ```{r results, cache=TRUE}
 # Assumption: use only one run, and the contrast you want is group
 # (treatment/control).
@@ -297,6 +296,33 @@ res.list.lookup <- list(
                         lfc2='Using a log2 fold change threshold of 2'
                         )
 ```
+
+
+```{r groupcounts, cache=TRUE}
+# Use normalized counts to get per-level mean counts. Attach them to results
+# for each result. This does ~not~ assume any particular model.
+for (name in names(res.list)) {
+    # extract the dds object in use
+    my.dds <- dds.list[[name]]
+    # get the normalized per-gene count data
+    my.counts <- counts(my.dds, TRUE)
+    # extract the design matrix
+    my.model <- model.matrix(design(my.dds), colData(my.dds))
+    # unique rows correspond to groups
+    my.unique.patterns <- unique(my.model)
+    # for each unique pattern
+    for (i in 1:nrow(my.unique.patterns)) {
+    	# determine which samples conform to that pattern
+    	in.pattern <- apply(my.model, 1, function(row) {all(row == my.unique.patterns[i,])})
+	# get counts just in those samples
+	in.counts <- rowSums(my.counts[,in.pattern])
+	res.list[[name]] <- cbind(res.list[[name]], in.counts)
+	colnames(res.list[[name]])[ncol(res.list[[name]])] <- format.group.name(my.unique.patterns[i,])
+    }
+}
+
+```
+
 
 ```{r attach, cache=TRUE, depends='results'}
 # Assumption: Original annotations use Ensembl IDs

--- a/wrappers/wrappers/sicer/environment.yaml
+++ b/wrappers/wrappers/sicer/environment.yaml
@@ -7,3 +7,4 @@ dependencies:
   - sicer
   - bedtools
   - ucsc-bedsort
+  - ucsc-wigtobigwig

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -131,6 +131,7 @@ else:
 shell(
     "export LC_COLLATE=C; "
     # format the output in broadPeak format
+    # note that SICER can emit p-values of 0 and in that case this file will contain "inf" entries
     """awk -F"\\t" -v lab={label} """
     """'{{printf("%s\\t%d\\t%d\\t%s_peak_%d\\t%d\\t.\\t%g\\t%g\\t%g\\n", $1, """
     """$2, $3-1, lab, NR, -10*log($6)/log(10), $7, -log($6)/log(10), -log($8)/log(10))}}' """

--- a/wrappers/wrappers/sicer/wrapper.py
+++ b/wrappers/wrappers/sicer/wrapper.py
@@ -63,13 +63,12 @@ os.chdir(tmpdir)
 shell(
     # there is a CI-specific bug, in which the python symlink is not correctly resolved to python2.7;
     # so as a really desperate hack, modify SICER's python calls to directly touch 2.7
-    # but only on circleci
-    """function fixci {{ if [[ "$CIRCLECI" == true ]] ; then sed -i 's/^python/$CONDA_PREFIX\/bin\/python2.7/' """
-    """$CONDA_PREFIX/share/sicer*/SICER.sh ; fi ; }} && fixci"""
+    """sed 's/^python/$CONDA_PREFIX\/bin\/python2.7/' """
+    """$CONDA_PREFIX/share/sicer*/SICER.sh > {tmpdir}/SICER.sh && chmod u+x {tmpdir}/SICER.sh """
 )
 shell(
     # run SICER
-    """SICER.sh {tmpdir} ip.bed in.bed {tmpdir} """
+    """{tmpdir}/SICER.sh {tmpdir} ip.bed in.bed {tmpdir} """
     """{genome_build} {redundancy_threshold} {window_size} """
     """{fragment_size} {effective_genome_fraction} {gap_size} {fdr} > tmp.output 2>&1 """
 )
@@ -141,8 +140,8 @@ shell(
     # rename the assorted output files
     "mv {resultsfile} {snakemake.output.bed}-islands-summary-significant && "
     "mv {summary_graph} {snakemake.output.bed}.graph && "
-    "mv {normalized_prefilter_wig} {snakemake.output.bed}-normalized-prefilter.wig && "
-    "mv {normalized_postfilter_wig} {snakemake.output.bed}-normalized-postfilter.wig && "
+    "wigToBigWig {normalized_prefilter_wig} {snakemake.input.chromsizes} {snakemake.output.bed}-normalized-prefilter.bigWig && "
+    "wigToBigWig {normalized_postfilter_wig} {snakemake.input.chromsizes} {snakemake.output.bed}-normalized-postfilter.bigWig && "
     "mv {candidate_islands} {snakemake.output.bed}-islands-summary && "
     "mv {significant_islands} {snakemake.output.bed}-island.bed && "
     "mv {redundancy_removed} {snakemake.output.bed}-islandfiltered.bed && "


### PR DESCRIPTION
1) assorted SICER bugs from lcdb-126:

   - biowulf rejected the original circleci workaround, so replacing it with a local (tmp) copy of SICER.sh with hardcoded python2 path
   - clusterconfig gets a SICER-specific handler
   - for now, just a comment that SICER emits p==0 in some instances, leading to "inf" entries in the broadPeak output file


2) SICER support in chipseq_trackhub.py from lcdb-125:

   - SICER wrapper now converts the SICER-native wig output files to bigWigs before dumping them in the output directory. Requires use of chromsizes file.
   - chipseq_trackhub.py recognizes SICER-style output and adds the pre- and post-filter signal bigWigs to the chipseq signal view.

3) rnaseq.Rmd generates count data from lcdb-77:

   - Salmon normalized counts are aggregated by gene
   - uses (bad and incomplete) orgdb lookup to map from ENSEMBLTRANS to ENSEMBL
   - per-sample counts are then pasted onto every output DE file
   - a separate counts file (ie all.tsv.counts) is now emitted, one per analysis object. Contains group-combined DESeq2 normalized count data. It's conceptually useful for model checking, to be sure all the various directions of effect make sense. This has not been tested on interaction models but is designed to work on them.
