### PR TITLE
Fix sorting error when adding count data to output

### DIFF
--- a/ci/get-data.py
+++ b/ci/get-data.py
@@ -4,7 +4,7 @@ from snakemake.shell import shell
 from snakemake.utils import makedirs
 
 shell.executable('/bin/bash')
-BRANCH = 'use-chr'
+BRANCH = 'master'
 URL = 'https://github.com/lcdb/lcdb-test-data/blob/{0}/data/{{}}?raw=true'.format(BRANCH)
 
 

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -147,7 +147,7 @@ references:
   dmel:
     test:
       fasta:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
         postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'

--- a/workflows/chipseq/config/config.yaml
+++ b/workflows/chipseq/config/config.yaml
@@ -148,7 +148,7 @@ references:
     test:
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
+        postprocess: 'lib.common.gzipped'
         indexes:
           - 'bowtie2'
       genome_build: dm6

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,6 +82,7 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
+        postprocess: 'lib.common.gzipped'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -49,7 +49,7 @@ references:
   dmel:
     test:
       gtf:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/annotation/dm6.small.gtf"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/annotation/dm6.small.gtf"
         postprocess: 'lib.common.gzipped'
         conversions:
           - 'refflat'
@@ -81,7 +81,7 @@ references:
         postprocess: "lib.postprocess.dm6.fb_synonym_postprocess"
 
       fasta:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
         postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
@@ -89,7 +89,7 @@ references:
 
     test_transcriptome:
       fasta:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.transcriptome.fa"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.transcriptome.fa"
         postprocess: 'lib.common.gzipped'
         indexes:
           - 'salmon'

--- a/workflows/references/config/config.yaml
+++ b/workflows/references/config/config.yaml
@@ -82,7 +82,6 @@ references:
 
       fasta:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
-        postprocess: 'lib.postprocess.dm6.fasta_postprocess'
         indexes:
           - 'bowtie2'
           - 'hisat2'

--- a/workflows/rnaseq/config/config.yaml
+++ b/workflows/rnaseq/config/config.yaml
@@ -80,7 +80,7 @@ references:
   dmel:
     test:
       gtf:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/annotation/dm6.small.gtf"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/annotation/dm6.small.gtf"
         postprocess: 'lib.common.gzipped'
         conversions:
           - 'refflat'
@@ -111,7 +111,7 @@ references:
         postprocess: "lib.postprocess.dm6.fb_synonym_postprocess"
 
       fasta:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.fa"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.fa"
         postprocess: 'lib.common.gzipped'
         indexes:
           - 'bowtie2'
@@ -119,7 +119,7 @@ references:
 
     test_transcriptome:
       fasta:
-        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/add-chipseq/data/seq/dm6.small.transcriptome.fa"
+        url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/seq/dm6.small.transcriptome.fa"
         postprocess: 'lib.common.gzipped'
         indexes:
           - 'salmon'

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -471,8 +471,14 @@ for (name in names(res.list)) {
     colnames(gene.tpm) <- c("Gene", colnames(my.normalized.counts))
 
     # report per-sample Salmon counts to output files
-    merged.results.deseq.counts <- merge(data.frame(res.list[[name]]), my.normalized.counts, by.x="gene", by.y="row.names", all.x=TRUE)
-    merged.results.salmon.tpm <- merge(data.frame(res.list[[name]]), gene.tpm, by.x="gene", by.y="Gene", all.x=TRUE)
+    merged.results.deseq.counts <- merge(data.frame(res.list[[name]]), my.normalized.counts, by.x="gene", by.y="row.names", all.x=TRUE, sort=FALSE)
+    merged.results.salmon.tpm <- merge(data.frame(res.list[[name]]), gene.tpm, by.x="gene", by.y="Gene", all.x=TRUE, sort=FALSE)
+    rownames(merged.results.deseq.counts) <- merged.results.deseq.counts$gene
+    rownames(merged.results.salmon.tpm)   <- merged.results.salmon.tpm$gene
+    merged.results.deseq.counts           <- merged.results.deseq.counts[rownames(res.list[[name]]),]
+    merged.results.salmon.tpm <- merged.results.salmon.tpm[rownames(res.list[[name]]),]
+    rownames(merged.results.deseq.counts) <- NULL
+    rownames(merged.results.salmon.tpm) <- NULL
     for (colname in colnames(my.normalized.counts)) {
         res.list[[name]][,paste('deseq2.counts', colname, sep='.')] <- merged.results.deseq.counts[,colname]
         res.list[[name]][,paste('avg.salmon.tpm', colname, sep='.')] <- merged.results.salmon.tpm[,colname]


### PR DESCRIPTION
All recent versions of rnaseq.Rmd with count reporting are wrong if the DESeq2 results tables are not already sorted by ascii sort on gene ID. This should patch the issue by forcing sorting to be synchronized.