### PR TITLE
Simplify patterns fixes

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -82,7 +82,7 @@ arguments will be described later, this is just to get things running:
 
 .. code-block:: bash
 
-    ./run_test.sh -n --use-conda --configfile ../../include/reference_configs/test.yaml
+    ./run_test.sh -n --use-conda
 
 If all goes well, you will get lots of output ending with a summary of the
 number of jobs that will be run. Then, use the same command but remove the
@@ -92,14 +92,17 @@ example just uses 2 cores):
 
 .. code-block:: bash
 
-    ./run_test.sh -j 2 --use-conda --configfile ../../include/reference_configs/test.yaml
+    ./run_test.sh -j 2 --use-conda
 
 This will take ~15 minutes to run.
 
-Briefly, this workflow first imports the references workflow, which downloads
-genome sequence and reference files and builds indexes as necessary (HISAT2
-genome index, salmon transcriptome index, bowtie2 index for rRNA, GTF file of
-gene annotations) and then carries on with the RNA-seq workflow.
+Briefly,the file ``config/config.yaml`` sets up lots of configuration like
+where the fastq files are found, how to build references, and so on. The
+workflow expects the file called ``config/config.yaml``; see :ref:`config` for
+more details. This workflow first imports the references workflow, which
+downloads genome sequence and reference files and builds indexes as necessary
+(HISAT2 genome index, salmon transcriptome index, bowtie2 index for rRNA, GTF
+file of gene annotations) and then carries on with the RNA-seq workflow.
 
 The RNA-seq workflow includes the standard mapping, counting, and differential
 expression stages, as well as many quality-control steps. See :ref:`rnaseq` for
@@ -130,7 +133,7 @@ arguments will be described later, this is just to get things running:
 
 .. code-block:: bash
 
-    ./run_test.sh -n --use-conda --configfile ../../include/reference_configs/test.yaml
+    ./run_test.sh -n --use-conda
 
 If all goes well, you will get lots of output ending with a summary of the
 number of jobs that will be run. Then, use the same command but remove the
@@ -140,12 +143,13 @@ example just uses 2 cores):
 
 .. code-block:: bash
 
-    ./run_test.sh -j 2 --use-conda --configfile ../../include/reference_configs/test.yaml
+    ./run_test.sh -j 2 --use-conda
 
-Like the RNA-seq workflow, the ChIP-seq workflow includes the
+Like the RNA-seq workflow, the ChIP-seq workflow expects
+a ``config/config.yaml`` file and includes the
 ``workflows/references/Snakemake`` workflow, so that genome fastas are
 downloaded and indexes built as necessary, before continuing on to the ChIP-seq
-workflow.
+workflow. The ChIP-seq workflow includes QC, mapping, and peak-calling.
 
 Points of interest:
 

--- a/include/reference_configs/test.yaml
+++ b/include/reference_configs/test.yaml
@@ -24,11 +24,14 @@ references:
           - genelist:
               gene_id: 'gene_id'
 
+          # Deprecated in favor of "mappings"
           # a <- AnnotationHub()
           # a[(a$rdataclass == 'OrgDb') & grepl('melanogaster', a$species),]
-          - annotation_hub:
-              ahkey: 'AH57972'
-              keytype: 'ENSEMBL'
+          # - annotation_hub:
+          #     ahkey: 'AH57972'
+          #    keytype: 'ENSEMBL'
+          #
+          - mappings
 
       metadata:
         reference_genome_build: 'dm6'

--- a/lib/common.py
+++ b/lib/common.py
@@ -590,14 +590,13 @@ def deprecation_handler(config):
 
     Also makes any fixes that can be done automatically.
     """
-    warnings.simplefilter('default')
     if 'assembly' in config:
         config['organism'] = config['assembly']
         warnings.warn(
             "'assembly' should be replaced with 'organism' in config files. "
             "As a temporary measure, a new 'organism' key has been added with "
             "the value of 'assembly'",
-            DeprecationWarning)
+            UserWarning)
 
 
     for org, block1 in config.get('references', {}).items():
@@ -610,6 +609,6 @@ def deprecation_handler(config):
                         "than 'annotation_hub' since it works directly off "
                         "the GTF file rather than assuming concordance between "
                         "GTF and AnnoationHub instances",
-                        DeprecationWarning)
+                        UserWarning)
 
     return config

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -236,8 +236,7 @@ rule mappings:
         # include_featuretypes settings, this may take a while.
         df = df.drop_duplicates()
 
-        with gzip.open(output[0], 'wt') as fout:
-            df.to_csv(fout, sep='\t', index=False)
+        df.to_csv(output[0], sep='\t', index=False, compression='gzip')
 
         # Restore original setting
         gffutils.constants.always_return_list = orig_setting


### PR DESCRIPTION
Some minor fixes to the recently merged "simplify-patterns" branch. Clarifications in docs, use new mappings in test config, and be less noisy about warnings.