### PR TITLE
invalidate cache to rebuild env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ variables:
 
   save_cache: &save_cache
     save_cache:
-      key: v2-{{ checksum "requirements.txt" }}
+      key: v3-{{ checksum "requirements.txt" }}
       paths:
         - miniconda
 


### PR DESCRIPTION
Rerunning locally on a new setup I'm not getting the bowtie2 `*.rev.{1,2}` index files. Trying to work out  if that's a new version issue. Re-creating the environment in circleci should test that.