### PR TITLE
update multiqc configs to work with v1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ kallisto
 lcdblib
 matplotlib
 multiqc
-pandas
+pandas ==0.22.0
 pandoc
 picard
 preseq

--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -22,12 +22,6 @@ extra_fn_clean_exts:
 sp:
   fastq_screen:
     fn: '*.screen.txt'
-  picard/rnaseqmetrics:
-    contents_re: '.*picard\.analysis\.[Rr]na[Ss]eq[Mm]etrics.*'
-    shared: true
-  picard/markdups:
-    contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
-    shared: true
 
 # Set the module order to reflect the order of the workflow. Note that here
 # we're also running the FastQC module multiple times, and putting them in

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -22,12 +22,6 @@ extra_fn_clean_exts:
 sp:
   fastq_screen:
     fn: '*.screen.txt'
-  picard/rnaseqmetrics:
-    contents_re: '.*picard\.analysis\.[Rr]na[Ss]eq[Mm]etrics.*'
-    shared: true
-  picard/markdups:
-    contents_re: '.*picard\.sam\.[Dd]uplication[Mm]etrics.*'
-    shared: true
 
 
 # Ignore the rRNA files, which were just cluttering the tables. We're


### PR DESCRIPTION
Removed some config items that are no longer needed; they otherwise cause multiqc v1.6 to hang.