### PR TITLE
Add support for NextGenMap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,16 @@ variables:
           ./run_test.sh --use-conda -j2 -T -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
 
+  rnaseq-ngm-step: &rnaseq-ngm-step
+      run:
+        name: rnaseq NGM aligner
+        command: |
+          rsync -arv --progress workflows/rnaseq workflows/rnaseq-ngm --exclude .snakemake
+          cd workflows/rnaseq-ngm
+          source activate lcdb-wf-test
+          ./run_test.sh --use-conda -T -k -p -r --forcerun ngm --until ngm --configfile config/config_ngm.yaml
+
+
   colocalization-step: &colocalization-step
       run:
         name: colocalization workflow
@@ -137,6 +147,15 @@ jobs:
       - *set-path
       - *get-data
       - *rnaseq-step
+
+  rnaseq-ngm:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *set-path
+      - *get-data
+      - *rnaseq-ngm-step
 
   colocalization:
     <<: *defaults
@@ -196,6 +215,14 @@ workflows:
              ignore:
                - master
       - rnaseq:
+          requires:
+            - initial-setup
+            - pytest
+          filters:
+            branches:
+              ignore:
+                - master
+      - rnaseq-ngm:
           requires:
             - initial-setup
             - pytest

--- a/include/reference_configs/test.yaml
+++ b/include/reference_configs/test.yaml
@@ -7,6 +7,7 @@ references:
         indexes:
           - 'bowtie2'
           - 'hisat2'
+          - 'ngm'
       gtf:
         url: "https://raw.githubusercontent.com/lcdb/lcdb-test-data/master/data/annotation/dm6.small.gtf"
         postprocess: 'lib.common.gzipped'

--- a/lib/common.py
+++ b/lib/common.py
@@ -336,12 +336,15 @@ def references_dict(config):
     ...          'gtf': '/data/dm6/r6-11/gtf/dm6_r6-11.gtf',
     ...          'chromsizes': '/data/dm6/r6-11/fasta/dm6_r6-11.chromsizes',
     ...          'bowtie2': '/data/dm6/r6-11/bowtie2/dm6_r6-11.1.bt2',
+    ...          'bowtie2_fasta': '/data/dm6/r6-11/bowtie2/dm6_r6-11.fasta',
     ...          'hisat2': '/data/dm6/r6-11/hisat2/dm6_r6-11.1.ht2',
+    ...          'hisat2_fasta': '/data/dm6/r6-11/hisat2/dm6_r6-11.fasta',
     ...          },
     ...      'r6-11_transcriptome': {
     ...          'fasta': '/data/dm6/r6-11_transcriptome/fasta/dm6_r6-11_transcriptome.fasta',
     ...          'chromsizes': '/data/dm6/r6-11_transcriptome/fasta/dm6_r6-11_transcriptome.chromsizes',
     ...          'salmon': '/data/dm6/r6-11_transcriptome/salmon/dm6_r6-11_transcriptome/hash.bin',
+    ...          'salmon_fasta': '/data/dm6/r6-11_transcriptome/salmon/dm6_r6-11_transcriptome.fasta',
     ...          },
     ...     },
     ... }), d
@@ -435,6 +438,13 @@ def references_dict(config):
 
                         e[index] = (
                             '{references_dir}/{organism}/{tag}/{index}/{organism}_{tag}{ext}'
+                            .format(**locals())
+                        )
+
+                        # Each index will get the original fasta symlinked over
+                        # to its directory
+                        e[index + '_fasta'] = (
+                            '{references_dir}/{organism}/{tag}/{index}/{organism}_{tag}.fasta'
                             .format(**locals())
                         )
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -358,6 +358,7 @@ def references_dict(config):
     index_extensions = {
         'bowtie2': aligners.bowtie2_index_from_prefix('')[0],
         'hisat2': aligners.hisat2_index_from_prefix('')[0],
+        'ngm': '.fasta-enc.2.ngm',
         'salmon': '/hash.bin'
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ kallisto
 lcdblib
 matplotlib
 multiqc
+nextgenmap
 numpy >1.15
 pandas ==0.22.0
 pandoc

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -28,7 +28,10 @@ shell.executable('/bin/bash')
 
 config = common.load_config(config)
 
-c = ChIPSeqConfig(config, 'config/chipseq_patterns.yaml')
+c = ChIPSeqConfig(
+    config,
+    config.get('patterns', 'config/chipseq_patterns.yaml')
+)
 
 
 def wrapper_for(path):

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -121,8 +121,8 @@ rule symlink_fasta_to_index_dir:
         '{references_dir}/{organism}/{tag}/{index}/{organism}_{tag}.fasta'
     log:
         '{references_dir}/logs/{organism}/{tag}/{index}/{organism}_{tag}.fasta.log'
-    shell:
-        'ln -sf {input} {output}'
+    run:
+        utils.make_relative_symlink(input[0], output[0])
 
 
 rule salmon_index:

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -78,6 +78,20 @@ rule bowtie2_index:
             '&> {log}')
 
 
+rule ngm_index:
+    input:
+        '{references_dir}/{organism}/{tag}/fasta/{organism}_{tag}.fasta'
+    output:
+        protected('{references_dir}/{organism}/{tag}/ngm/{organism}_{tag}.fasta-enc.2.ngm')
+    log:
+        '{references_dir}/logs/{organism}/{tag}/ngm/{organism}_{tag}.log'
+    run:
+        prefix = aligners.prefix_from_bowtie2_index(output)
+
+        shell('ngm ' '-r {input} ' '&> {log}')
+        shell('mv {input}-enc.2.ngm $(dirname {output})')
+
+
 rule hisat2_index:
     """
     Build HISAT2 index

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -235,18 +235,52 @@ if config['aligner']['index'] == 'ngm':
         """
         input:
             fastq=common.fill_r1_r2(c.sampletable, c.patterns['cutadapt']),
-            index=[c.refdict[c.organism][config['aligner']['tag']]['ngm']]
+            index=[c.refdict[c.organism][config['aligner']['tag']]['ngm']],
+            fasta=[c.refdict[c.organism][config['aligner']['tag']]['ngm_fasta']]
         output:
             bam=c.patterns['bam']
-
         log:
             c.patterns['bam'] + '.log'
-        params:
-            samtools_view_extra='-F 0x04',
-            ngm_extra='--min-identity 0.9'
         threads: 6
-        wrapper:
-            wrapper_for('ngm/align')
+        run:
+            if common.is_paired_end(c.sampletable, wildcards.sample):
+                fastqs = '-1 {0} -2 {1} '.format(*input.fastq)
+            else:
+                fastqs = '--qry {0} '.format(input.fastq)
+
+            prefix = input.index[0].replace('-enc.2.ngm', '')
+
+            output_prefix = output.bam.replace('.bam', '')
+
+            shell(
+                "ngm "
+                "-r {prefix} "
+                "{fastqs} "
+                "-t {threads} "
+                "-o {output_prefix}.sam "
+                # NOTE: add extra NextGenMap options here.
+                "&> {log}"
+            )
+
+            shell(
+                "samtools view -Sb "
+                # NOTE: change samtools view arguments here if needed; default
+                # is to remove unmapped reads
+                "-F 0x04 "
+                "{output_prefix}.sam "
+                "> {output_prefix}.tmp.bam && rm {output_prefix}.sam"
+            )
+
+            shell(
+                "samtools sort "
+                "-o {output.bam} "
+                # NOTE: optionally provide other sort arguments here. If you
+                # increase threads, you may need to increase memory in the
+                # clusterconfig as well.
+                "-O BAM "
+                "{output_prefix}.tmp.bam "
+                "&& rm {output_prefix}.tmp.bam "
+            )
 
 
 rule rRNA:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -261,6 +261,9 @@ rule rRNA:
     log:
         c.patterns['rrna']['bam'] + '.log'
     params:
+        # NOTE: we'd likely only want to report a single alignment for rRNA
+        # screening
+        bowtie2_extra='-k 1',
         samtools_view_extra='-F 0x04'
     threads: 6
     wrapper:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -207,25 +207,46 @@ rule fastqc:
         wrapper_for('fastqc')
 
 
-rule hisat2:
-    """
-    Map reads with HISAT2
-    """
-    input:
-        fastq=common.fill_r1_r2(c.sampletable, c.patterns['cutadapt']),
-        index=[c.refdict[c.organism][config['aligner']['tag']]['hisat2']]
-    output:
-        bam=c.patterns['bam']
-    log:
-        c.patterns['bam'] + '.log'
-    params:
-        # NOTE: see examples at
-        # https://github.com/lcdb/lcdb-wf/tree/master/wrappers/wrappers/hisat2/align
-        # for details on setting hisat2 params and samtools params separately.
-        samtools_view_extra='-F 0x04'
-    threads: 6
-    wrapper:
-        wrapper_for('hisat2/align')
+if config['aligner']['index'] == 'hisat2':
+    rule hisat2:
+        """
+        Map reads with HISAT2
+        """
+        input:
+            fastq=common.fill_r1_r2(c.sampletable, c.patterns['cutadapt']),
+            index=[c.refdict[c.organism][config['aligner']['tag']]['hisat2']]
+        output:
+            bam=c.patterns['bam']
+        log:
+            c.patterns['bam'] + '.log'
+        params:
+            # NOTE: see examples at
+            # https://github.com/lcdb/lcdb-wf/tree/master/wrappers/wrappers/hisat2/align
+            # for details on setting hisat2 params and samtools params separately.
+            samtools_view_extra='-F 0x04'
+        threads: 6
+        wrapper:
+            wrapper_for('hisat2/align')
+
+if config['aligner']['index'] == 'ngm':
+    rule ngm:
+        """
+        Map reads with NextGenMap
+        """
+        input:
+            fastq=common.fill_r1_r2(c.sampletable, c.patterns['cutadapt']),
+            index=[c.refdict[c.organism][config['aligner']['tag']]['ngm']]
+        output:
+            bam=c.patterns['bam']
+
+        log:
+            c.patterns['bam'] + '.log'
+        params:
+            samtools_view_extra='-F 0x04',
+            ngm_extra='--min-identity 0.9'
+        threads: 6
+        wrapper:
+            wrapper_for('ngm/align')
 
 
 rule rRNA:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -26,7 +26,7 @@ shell.executable('/bin/bash')
 
 config = common.load_config(config)
 
-c = RNASeqConfig(config, 'config/rnaseq_patterns.yaml')
+c = RNASeqConfig(config, config.get('patterns', 'config/rnaseq_patterns.yaml'))
 
 
 def wrapper_for(path):

--- a/workflows/rnaseq/config/config.yaml
+++ b/workflows/rnaseq/config/config.yaml
@@ -1,5 +1,7 @@
 sampletable: 'config/sampletable.tsv'
 
+patterns: 'config/rnaseq_patterns.yaml'
+
 # Which key in the `references` dict below to use
 organism: 'dmel'
 

--- a/wrappers/wrappers/ngm/align/environment.yaml
+++ b/wrappers/wrappers/ngm/align/environment.yaml
@@ -1,0 +1,7 @@
+channels:
+  - bioconda
+  - lcdb
+dependencies:
+  - nextgenmap
+  - samtools ==1.4.1
+  - lcdblib ==0.1.2.post

--- a/wrappers/wrappers/ngm/align/wrapper.py
+++ b/wrappers/wrappers/ngm/align/wrapper.py
@@ -1,0 +1,54 @@
+__author__ = "Ryan Dale"
+__copyright__ = "Copyright 2016, Ryan Dale"
+__email__ = "dalerr@niddk.nih.gov"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+from lcdblib.snakemake import aligners
+
+ngm_extra = snakemake.params.get('ngm_extra', '')
+samtools_view_extra = snakemake.params.get('samtools_view_extra', '')
+samtools_sort_extra = snakemake.params.get('samtools_sort_extra', '')
+
+log = snakemake.log_fmt_shell()
+
+# Handle paired-end reads. Since snakemake automatically converts a one-element
+# list to a string, here we detect single-end reads by checking if input.fastq
+# is a string.
+if isinstance(snakemake.input.fastq, str):
+    fastqs = '--qry {0} '.format(snakemake.input.fastq)
+else:
+    assert len(snakemake.input.fastq) == 2
+    fastqs = '-1 {0} -2 {1} '.format(*snakemake.input.fastq)
+
+prefix = snakemake.input.index.replace('-enc.2.ngm', '')
+
+output_prefix = snakemake.output.bam.replace('.bam', '')
+
+shell(
+    "ngm "
+    "-r {prefix} "
+    "{fastqs} "
+    "-t {snakemake.threads} "
+    "{ngm_extra} "
+    "-o {output_prefix}.sam "
+    "{log}"
+)
+
+# ngm outputs SAM format so we convert to BAM here.
+shell(
+    "samtools view -Sb "
+    "{samtools_view_extra} "
+    "{output_prefix}.sam "
+    "> {output_prefix}.tmp.bam && rm {output_prefix}.sam"
+)
+
+# sort the BAM and clean up
+shell(
+    "samtools sort "
+    "-o {snakemake.output.bam} "
+    "{samtools_sort_extra} "
+    "-O BAM "
+    "{output_prefix}.tmp.bam "
+    "&& rm {output_prefix}.tmp.bam "
+)


### PR DESCRIPTION
Previously we've only supported HISAT2 and Bowtie2. I'd like to support other aligners as well, and have them tested. Here's the first one, NextGenMap (next up will be STAR).

This includes a separate test on CircleCI that makes a copy of the rnaseq workflow dir and only runs up to (and including) the ngm mapping stage.