### PR TITLE
Cluster-specific details

### DIFF
--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -8,6 +8,20 @@ Snakemake `supports arbitrary cluster commands
 <http://snakemake.readthedocs.io/en/latest/snakefiles/configuration.html>`_,
 making it easy to run these workflows on many different cluster environments.
 
+Snakemake, and these workflows, are designed to decouple the code from the
+configuration. If you are running the workflows on NIH's Biowulf cluster, you
+don't need to change anything. If you are running on a different cluster, you
+should inspect the following files:
+
+- `include/WRAPPER_SLURM` (see :ref:`wrapper`)
+- the `config/clusterconfig.yaml` files in each workflow directory you will be
+  using (see :ref:`clusterconfig`)
+- `lib/cluster_specific.py`. This module currently has a single function that,
+  when called, will inspect the current environment variables and make any
+  necessary changes, returning the temp dir. Other cluster-specific code may go
+  here (see `cluster_specific`)
+
+
 The default configuration we provide is specific to the NIH Biowulf cluster.
 To run a workflow on Biowulf, from the workflow directory (e.g.,
 ``workflows/rnaseq``, run the following command::
@@ -29,3 +43,37 @@ This means that each job is named after the rule and job id (the ``--jobname``
 arg) and the stdout and stderr go to files in ``logs`` and are named after the
 rule, followed by a ``.o`` or ``.e``, followed by the cluster job ID (the
 ``--cluster`` arg).
+
+.. _cluster_specific:
+
+TMPDIR handling
+~~~~~~~~~~~~~~~
+The top of each snakefile sets up a shell prefix that exports the TMPDIR
+variable. The reason for this is that the NIH Biowulf cluster supports nodes
+with temporary local storage in a directory named after the SLURM job ID. This
+ID is not known ahead of time, but is stored in the ``SLURM_JOBID`` env var.
+
+Since each rule executed on a cluster node calls the snakefile (see the job
+scripts created by snakemake for more on this), we can look for the job ID and
+set the tempdir appropriately. Upon setting ``$TMPDIR``, the Python
+``tempfile`` module will use that directory to store temp files. Any wrappers
+can additionally use ``$TMPDIR`` in shell commands and it will use this
+directory.
+
+Note that the default behavior -- if the ``SLURM_JOBID`` env var is not set --
+is to set ``$TMPDIR`` to the default temp directory as documented in Python's
+`tempfile module
+< https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir>`_.
+However if you use these workflows on a different cluster, you may need to
+provide a different function to return the job-specific temp directory.
+
+
+``clusterconfig.yaml`` files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `snakemake cluster configuration docs
+<https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html#cluster-configuration>`_
+describe how to configure cluster-specific settings so that rules will run on
+the correct size node when submitting batch jobs. This is not needed if you are
+running the workflows locally, but you may need to edit the
+`config/clusterconfig.yaml` file found in each workflow directory.

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -67,6 +67,7 @@ is to set ``$TMPDIR`` to the default temp directory as documented in Python's
 However if you use these workflows on a different cluster, you may need to
 provide a different function to return the job-specific temp directory.
 
+.. _clusterconfig:
 
 ``clusterconfig.yaml`` files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/references-config.rst
+++ b/docs/references-config.rst
@@ -483,9 +483,9 @@ The following conversions can be specified for GTF files:
     You can include/exclude featuretypes from being checked.  For example, if
     your GTF has genes and transcripts in addition to exons, the gene and
     transcript lines probably contain all of the attributes you are interested
-    in, and the exon (and any other lines) can be ignored, speeding up the
-    process. In this case you could use ``include_featuretypes: [gene,
-    transcript]``.
+    in (like gene_id, symbol, name, etc) and the exon (and any other lines) can
+    be ignored, speeding up the process. In this case you could use
+    ``include_featuretypes: [gene, transcript]``.
 
     A ``__featuretype__`` column is always included in the mapping.  This is
     the GTF featuretype of each line, with extra ``__`` to avoid overwriting an

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -98,9 +98,41 @@ Each workflow is driven by a ``Snakefile`` and is configured by plain text
 :ref:`config` for much more on this).  In this section, we will take
 a higher-level look at the features common to the primary analysis workflows.
 
+Features common to workflows
+----------------------------
+The directory ``../..`` is added to Python's path. This way, the ``../../lib``
+module can be found, and we can use the various helper functions there. This is
+also simpler than providing a `setup.py` to install the helper functions.
+
+The config file is hard-coded to be `config/config.yaml`, but this can be
+overridden by Snakemake from the commandline, using ``snakemake --configfile
+<path to other config file>``. This allows the config file to be in the
+`config` dir with other config files without having to be specified on the
+command line, while also affording the user flexibility.
+
+The config file is loaded using ``common.load_config``. This function resolves
+various paths (especially the `includ`-ed reference configs) and checks to see
+if the config is well-formatted.
+
+A `SeqConfig` object is created. It needs that parsed config file as well as
+the patterns file (see :ref:`patterns-and-targets`). The act of creating this
+object reads the sample table, fills in the patterns with sample names, creates
+a reference dictionary (see ``common.references_dict``) for easy access to
+reference files, and for ChIP-seq, also fills in the filenames for the
+configured peak-calling runs. This object, called ``c`` for convenience, can be
+accesto get all sort of information -- ``c.sampletable``, ``c.config``,
+``c.patterns``, ``c.targets``, and ``c.refdict`` are frequently used in rules
+throughout the Snakefiles.
+
+
+Cluster-specific settings
+-------------------------
+See :ref:`cluster` for details.
+
+
 Primary analysis workflows
 --------------------------
-While the references workflow can be run stand-alone, but usually it is run as
+While the references workflow can be run stand-alone, usually it is run as
 a by-product of running the RNA-seq or ChIP-seq workflows. See
 :ref:`references` for details; here we will focus on RNA-seq and ChIP-seq which
 share common properties.
@@ -137,5 +169,3 @@ comments that say `# [TEST SETTINGS]`; you can ignore these, and see
 
         cp -r workflows/rnaseq workflows/genome1-rnaseq
         cp -r workflows/rnaseq workflows/genome2-rnaseq
-
-

--- a/lib/cluster_specific.py
+++ b/lib/cluster_specific.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+
+
+def tempdir_for_biowulf():
+    """
+    Get an appropriate tempdir.
+
+    The NIH biowulf cluster allows nodes to have their own /lscratch dirs as
+    local temp storage. However the particular dir depends on the slurm job ID,
+    which is not known in advance. This function sets the shell.prefix to use
+    such a tempdir if it's available; otherwise it leaves TMPDIR unchanged.
+    This makes it suitable for running locally or on other clusters, however if
+    you need different behavior for a different cluster, then a different
+    function will need to be written.
+    """
+    tmpdir = tempfile.gettempdir()
+    jobid = os.getenv('SLURM_JOBID')
+    if jobid:
+        tmpdir = os.path.join('/lscratch', jobid)
+    return tmpdir

--- a/lib/common.py
+++ b/lib/common.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import tempfile
 import warnings
 import yaml
 import pandas
@@ -458,25 +457,6 @@ def references_dict(config):
                     )
                 d[organism][tag] = e
     return d, conversion_kwargs
-
-
-def tempdir_for_biowulf():
-    """
-    Get an appropriate tempdir.
-
-    The NIH biowulf cluster allows nodes to have their own /lscratch dirs as
-    local temp storage. However the particular dir depends on the slurm job ID,
-    which is not known in advance. This function sets the shell.prefix to use
-    such a tempdir if it's available; otherwise it leaves TMPDIR unchanged.
-    This makes it suitable for running locally or on other clusters, however if
-    you need different behavior for a different cluster, then a different
-    function will need to be written.
-    """
-    tmpdir = tempfile.gettempdir()
-    jobid = os.getenv('SLURM_JOBID')
-    if jobid:
-        tmpdir = os.path.join('/lscratch', jobid)
-    return tmpdir
 
 
 def get_references_dir(config):

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -10,6 +10,7 @@ import pybedtools
 from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common, chipseq
+from lib import cluster_specific
 from lib.patterns_targets import ChIPSeqConfig
 
 # ----------------------------------------------------------------------------
@@ -23,7 +24,7 @@ from lib.patterns_targets import ChIPSeqConfig
 configfile: 'config/config.yaml'
 include: '../references/Snakefile'
 
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
 config = common.load_config(config)

--- a/workflows/colocalization/Snakefile
+++ b/workflows/colocalization/Snakefile
@@ -8,6 +8,7 @@ import pandas as pd
 from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common
+from lib import cluster_specific
 from lib.patterns_targets import RNASeqConfig, ChIPSeqConfig
 import os
 from snakemake.utils import makedirs
@@ -16,7 +17,7 @@ import yaml
 import numpy as np
 
 configfile: 'config/config.yaml'
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
 chipseq_config = ChIPSeqConfig('config/config.yaml', 'config/chipseq_patterns.yaml', workdir='../chipseq')

--- a/workflows/external/Snakefile
+++ b/workflows/external/Snakefile
@@ -1,10 +1,11 @@
 import sys
 sys.path.insert(0, srcdir('../..'))
+from lib import cluster_specific
 from lib import common
 import pybedtools
 
 
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
 # This is a useful construct for mapping intended output filenames to the URLs

--- a/workflows/figures/Snakefile
+++ b/workflows/figures/Snakefile
@@ -23,7 +23,11 @@ sys.path.insert(0, srcdir('../..'))
 import os
 from lcdblib.utils import utils
 from lib import common
+from lib import cluster_specific
 from lib.patterns_targets import RNASeqConfig, ChIPSeqConfig
+
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
+shell.executable('/bin/bash')
 
 rnaseq_config = RNASeqConfig('config/config.yaml', 'config/rnaseq_patterns.yaml', workdir='../rnaseq')
 chipseq_config = ChIPSeqConfig('config/config.yaml', 'config/chipseq_patterns.yaml', workdir='../chipseq')

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -10,15 +10,16 @@ from snakemake.utils import makedirs
 from lcdblib.utils.imports import resolve_name
 from lcdblib.utils import utils
 from lcdblib.snakemake import aligners, helpers
+from lib import cluster_specific
 from lib import common
 
 configfile: 'config/config.yaml'
 
 config = common.load_config(config)
 
-tempfile.tempdir = common.tempdir_for_biowulf()
+tempfile.tempdir = cluster_specific.tempdir_for_biowulf()
 
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 references_dir = common.get_references_dir(config)
 refdict, conversion_kwargs = common.references_dict(config)

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -8,6 +8,7 @@ import pandas as pd
 from lcdblib.snakemake import helpers, aligners
 from lcdblib.utils import utils
 from lib import common
+from lib import cluster_specific
 from lib.patterns_targets import RNASeqConfig
 
 # ----------------------------------------------------------------------------
@@ -21,7 +22,7 @@ from lib.patterns_targets import RNASeqConfig
 configfile: 'config/config.yaml'
 include: '../references/Snakefile'
 
-shell.prefix('set -euo pipefail; export TMPDIR={};'.format(common.tempdir_for_biowulf()))
+shell.prefix('set -euo pipefail; export TMPDIR={};'.format(cluster_specific.tempdir_for_biowulf()))
 shell.executable('/bin/bash')
 
 config = common.load_config(config)


### PR DESCRIPTION
This PR pulls out the "tempdir_for_biowulf" function from `lib/common.py` and puts it in a new `lib/cluster_specific.py`. That way there is a single place to put cluster-specific details.

I updated the docs to reflect this, and to point out what needs to change to make things work on a different cluster.