### PR TITLE
various cleanups

### DIFF
--- a/test/test_configs/test_sra_sampletable.tsv
+++ b/test/test_configs/test_sra_sampletable.tsv
@@ -1,2 +1,3 @@
 samplename	Run	layout
 sra1	SRR948304	SINGLE
+sra2	SRR948304	PAIRED

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -31,7 +31,7 @@ def wrapper_for(path):
     return 'file:' + os.path.join('../..','wrappers', 'wrappers', path)
 
 
-localrules: symlink_fasta_to_index_dir, chromsizes
+localrules: symlink_fasta_to_index_dir
 
 rule all_references:
     input: utils.flatten(refdict)
@@ -218,10 +218,18 @@ rule chromsizes:
         protected('{references_dir}/{organism}/{tag}/fasta/{organism}_{tag}.chromsizes')
     log:
         '{references_dir}/logs/{organism}/{tag}/fasta/{organism}_{tag}.fasta.log'
+    params:
+        # NOTE: Be careful with the memory here; make sure you have enough
+        # and/or it matches the resources you're requesting in the cluster
+        # config.
+        java_args='-Xmx20g'
+        # java_args='-Xmx2g'  # [TEST SETTINGS -1]
     shell:
         'export LC_COLLATE=C; '
         'rm -f {output}.tmp '
-        '&& picard CreateSequenceDictionary R={input} O={output}.tmp &> {log} '
+        '&& picard '
+        '{params.java_args} '
+        'CreateSequenceDictionary R={input} O={output}.tmp &> {log} '
         '&& grep "^@SQ" {output}.tmp '
         '''| awk '{{print $2, $3}}' '''
         '| sed "s/SN://g;s/ LN:/\\t/g" '

--- a/workflows/references/config/clusterconfig.yaml
+++ b/workflows/references/config/clusterconfig.yaml
@@ -9,3 +9,6 @@ hisat2_index:
 
 salmon_index:
   prefix: "--mem=32g"
+
+chromsizes:
+  prefix: "--gres=lscratch:20 --time=4:00:00 --mem=32g"

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -144,11 +144,11 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
                 # The filenames are predictable, so we can move them as needd.
                 shell(
                     'mv {srr}_1.fastq.gz '
-                    '$(dirname {output})/{sample}_R1.fastq.gz'
+                    '$(dirname {output})/{wildcards.sample}_R1.fastq.gz'
                 )
                 shell(
                     'mv {srr}_2.fastq.gz '
-                    '$(dirname {output})/{sample}_R2.fastq.gz'
+                    '$(dirname {output})/{wildcards.sample}_R2.fastq.gz'
                 )
 
             else:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -129,7 +129,7 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
             # Two different paths depending on the layout. In both cases, we
             # want to avoid creating the final output until the very end, to
             # avoid incomplete downloads.
-            if _st.loc[wildcards.sample, 'layout'] == 'PE':
+            if common.is_paired_end(c.sampletable, wildcards.sample):
 
                 # For PE we need to use --split-files, which also means using
                 # the slower --gzip


### PR DESCRIPTION
- test single-end and paired-end SRA downloads in the same sampletable
- be smarter about PE/SE detection from sampletable in fastq_dump rule
- fix typo in fastq_dump PE download
- move references workflow's chromsizes rule away from a localrule, since human and mouse needed a lot of RAM (@esnaultc this merges the `function_changes` branch)