### PR TITLE
Fix issue 145 (redo)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ variables:
 
   save_cache: &save_cache
     save_cache:
-      key: v2-{{ checksum "requirements.txt" }}
+      key: v0-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/setup.sh" }}
       paths:
         - miniconda
 
   restore_cache: &restore_cache
     restore_cache:
       keys:
-        - v2-{{ checksum "requirements.txt" }}
+        - v0-{{ checksum "requirements.txt" }}-{{ checksum ".circleci/setup.sh" }}
 
 
   # --------------------------------------------------------------------------

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -36,5 +36,7 @@ if ! type conda > /dev/null; then
     conda update -y conda
     conda create -n lcdb-wf-test -y --file requirements.txt
     conda remove -y r-base
+
+    yum install -y git
 fi
 

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 WORKSPACE=`pwd`
-MINICONDA_VER=latest
+MINICONDA_VER=4.3.21
 
 # Set path
 echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
@@ -31,6 +31,10 @@ if ! type conda > /dev/null; then
     conda config --system --add channels bioconda
     conda config --system --add channels lcdb
 
+    # After SSHing in, for some reason this seems to fix it...
+    conda install -y r-base=3.4.1 bioconductor-genomeinfodbdata bioconductor-annotationhub
+    conda update -y conda
     conda create -n lcdb-wf-test -y --file requirements.txt
+    conda remove -y r-base
 fi
 

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -2,22 +2,11 @@
 set -e
 
 WORKSPACE=`pwd`
-MINICONDA_VER=4.3.21
+MINICONDA_VER=latest
 
 # Set path
 echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
 source $BASH_ENV
-
-cat > ~/.condarc <<EOF
-channels:
-  - bioconda
-  - conda-forge
-  - defaults
-  - lcdb
-default_channels:
-  - https://repo.continuum.io/pkgs/main
-  - https://repo.continuum.io/pkgs/free
-EOF
 
 if ! type conda > /dev/null; then
     echo "Setting up conda..."
@@ -42,10 +31,6 @@ if ! type conda > /dev/null; then
     conda config --system --add channels bioconda
     conda config --system --add channels lcdb
 
-    # After SSHing in, for some reason this seems to fix it...
-    conda install -y r-base=3.4.1 bioconductor-genomeinfodbdata bioconductor-annotationhub
-    conda update -y conda
     conda create -n lcdb-wf-test -y --file requirements.txt
-    conda remove -y r-base
 fi
 

--- a/include/WRAPPER_SLURM
+++ b/include/WRAPPER_SLURM
@@ -11,7 +11,6 @@ if [[ ! -e logs ]]; then mkdir -p logs; fi
     time snakemake \
     -p \
     --directory $PWD \
-    # -T \
     -k \
     --rerun-incomplete \
     --jobname "s.{rulename}.{jobid}.sh" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ pytest
 pytest-xdist
 r-codetools
 r-dt
+r-kernsmooth
 r-knitr
 r-knitrbootstrap
 r-pheatmap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-r-base >=3.4
 python >=3.6
+r-base <3.5.1
 atropos
 bedtools
 bioconductor-annotationhub
@@ -35,7 +35,6 @@ matplotlib
 multiqc
 nextgenmap
 numpy >1.15
-pandas ==0.22.0
 pandoc
 picard
 preseq

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ fastq-screen
 font-ttf-dejavu-sans-mono
 
 gat
+git
 gffutils
 ghostscript
 graphviz

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -214,8 +214,8 @@ rule fastqc:
     output:
         html='{sample_dir}/{sample}/fastqc/{sample}{suffix}_fastqc.html',
         zip='{sample_dir}/{sample}/fastqc/{sample}{suffix}_fastqc.zip',
-    wrapper:
-        wrapper_for('fastqc')
+    script:
+        wrapper_for('fastqc/wrapper.py')
 
 
 rule bowtie2:
@@ -235,8 +235,8 @@ rule bowtie2:
     # When running on a cluster, number of threads here should match the
     # resources requested in the cluster config.
     threads: 8
-    wrapper:
-        wrapper_for('bowtie2/align')
+    script:
+        wrapper_for('bowtie2/align/wrapper.py')
 
 
 rule unique:
@@ -315,8 +315,8 @@ rule fastq_screen:
     log:
         c.patterns['fastq_screen'] + '.log'
     params: subset=100000
-    wrapper:
-        wrapper_for('fastq_screen')
+    script:
+        wrapper_for('fastq_screen/wrapper.py')
 
 
 rule libsizes_table:
@@ -463,8 +463,8 @@ rule merge_techreps:
         # config.
         java_args='-Xmx32g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
-    wrapper:
-        wrapper_for('combos/merge_and_dedup')
+    script:
+        wrapper_for('combos/merge_and_dedup/wrapper.py')
 
 
 rule bigwig:
@@ -728,7 +728,7 @@ if 'merged_bigwigs' in config:
             c.patterns['merged_bigwig']
         log:
             c.patterns['merged_bigwig'] + '.log'
-        wrapper:
-            wrapper_for('average-bigwigs')
+        script:
+            wrapper_for('average-bigwigs/wrapper.py')
 
 # vim: ft=python

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -395,7 +395,7 @@ rule rRNA:
         samtools_view_extra='-F 0x04'
     threads: 6
     script:
-        wrapper_for('bowtie2/align/wrapper.py)
+        wrapper_for('bowtie2/align/wrapper.py')
 
 
 rule fastq_count:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -221,8 +221,8 @@ rule fastqc:
     output:
         html='{sample_dir}/{sample}/fastqc/{sample}{suffix}_fastqc.html',
         zip='{sample_dir}/{sample}/fastqc/{sample}{suffix}_fastqc.zip',
-    wrapper:
-        wrapper_for('fastqc')
+    script:
+        wrapper_for('fastqc/wrapper.py')
 
 
 if config['aligner']['index'] == 'hisat2':
@@ -243,8 +243,8 @@ if config['aligner']['index'] == 'hisat2':
             # for details on setting hisat2 params and samtools params separately.
             samtools_view_extra='-F 0x04'
         threads: 6
-        wrapper:
-            wrapper_for('hisat2/align')
+        script:
+            wrapper_for('hisat2/align/wrapper.py')
 
 if config['aligner']['index'] == 'star':
     rule star:
@@ -394,8 +394,8 @@ rule rRNA:
         bowtie2_extra='-k 1',
         samtools_view_extra='-F 0x04'
     threads: 6
-    wrapper:
-        wrapper_for('bowtie2/align')
+    script:
+        wrapper_for('bowtie2/align/wrapper.py)
 
 
 rule fastq_count:
@@ -457,8 +457,8 @@ rule fastq_screen:
     log:
         c.patterns['fastq_screen'] + '.log'
     params: subset=100000
-    wrapper:
-        wrapper_for('fastq_screen')
+    script:
+        wrapper_for('fastq_screen/wrapper.py')
 
 
 rule featurecounts:
@@ -737,8 +737,8 @@ rule dupRadar:
         model=c.patterns['dupradar']['model'],
         curve=c.patterns['dupradar']['curve'],
     log: c.patterns['dupradar']['dataframe'] + '.log'
-    wrapper:
-        wrapper_for('dupradar')
+    script:
+        wrapper_for('dupradar/wrapper.py')
 
 
 rule salmon:
@@ -925,7 +925,7 @@ if 'merged_bigwigs' in config:
             c.patterns['merged_bigwig']
         log:
             c.patterns['merged_bigwig'] + '.log'
-        wrapper:
-            wrapper_for('average-bigwigs')
+        script:
+            wrapper_for('average-bigwigs/wrapper.py')
 
 # vim: ft=python


### PR DESCRIPTION
This took soooo much more work than it should have (had to throw out most of #146 after spending a ton of time on it).

1. Wrappers are now only used for cases where we actually need the independent environment (e.g., where py2 is required). The remainder are used as scripts rather than wrappers. This allows them to use the main environment, and cuts down a lot on env creation at run time.

2. There was a big mess with fastqc's java VM complaining about fonts, which actually didn't stop the workflow but instead just hung. Now fastqc is using the global env which seems to have solved it. I believe this was related to an interaction between the conda channels we were using and the conda channels indicated in the environment.yaml. Specifically, we weren't pulling the right openjdk from defaults.

3. As part of that troubleshooting I went down the rabbit hole of using "machine" mode instead of "docker" mode in circleci. This was a waste of time; I eventually discovered that the jobs do not run as login shells, causing conda to not actually add the env to the path when `source activate`ing in a wrapper. Something to do with `.bashrc` not getting checked in non-login shells. The only solution I could see there was adding a circle-ci-specific shell prefix to each wrapper script, which would have been uuuugly. Which brings me to  . . .

4. Over the course of this I realized that `shell.prefix()`, as set in the Snakefile, **does not propagate to scripts or wrappers**. They are run in a separate Python process, and the pickled Snakemake object does not contain the shell prefix. This means that our scripts and wrappers **will not use lscratch** because we're setting that in shell.prefix in the Snakefile but not independently in the scripts. I'm working on a PR to snakemake to fix that.