### PR TITLE
V1.4rc

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+v1.4
+----
+RNA-seq
+~~~~~~~
+Much-improved ``rnaseq.Rmd``:
+
+- tabbed PCA plot
+- improved DEGpatterns chunk
+- dramatically improved functional enrichment section, with tabbed clusterprofiler plots and exported data in two flavors (combined and split)
+- improved upset plots, with exported files showing sets of genes
+- improved comments to highlight where to make changes
+- add new helper functions to ``helpers.R``:
+   - ``fromList.with.names``, for getting UpSet plot output
+   - ``rownames.first.col``, to make tidier dataframes
+   - ``nested.lapply``, for convenient 2-level nested list apply
+   - clusterprofiler helper functions
+
+
 v1.3
 ----
 Bugfixes

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -29,9 +29,9 @@ Otherwise, install `Miniconda <https://conda.io/miniconda.html>`_.
 
 .. code-block:: bash
 
-    conda config --add channels defaults
-    conda config --add channels bioconda
-    conda config --add channels conda-forge
+   conda config --add channels defaults
+   conda config --add channels bioconda
+   conda config --add channels conda-forge
 
 
 Setup required once per project

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ bioconductor-deseq2
 bioconductor-dupradar
 bioconductor-genomeinfodbdata
 bioconductor-genomicfeatures
+bioconductor-reactomepa
 bioconductor-s4vectors
 bioconductor-sva
 bioconductor-tximport

--- a/workflows/rnaseq/downstream/help_docs.Rmd
+++ b/workflows/rnaseq/downstream/help_docs.Rmd
@@ -92,13 +92,12 @@ https://bioconductor.org/packages/3.7/bioc/vignettes/DESeq2/inst/doc/DESeq2.html
 
 To summarize:
 
-=============== ==== ==== ========
-log2FoldChange  pval padj Meaning
-=============== ==== ==== ========
-NA              NA   NA   Zero counts in all samples
-.               NA   NA   At least one replicate was an outlier and removed from analysis
-.               .    NA   Gene was removed by automatic independent filtering for having too little information
-=============== ==== ==== ========
+
+| log2FoldChange | pval | padj | Meaning                                                                               |
+|----------------+------+------+---------------------------------------------------------------------------------------|
+| NA             | NA   | NA   | Zero counts in all samples                                                            |
+| .              | NA   | NA   | At least one replicate was an outlier and removed from analysis                       |
+| .              | .    | NA   | Gene was removed by automatic independent filtering for having too little information |
 
 ### What is an MA plot?
 An MA plot is another name for a Bland-Altman plot or a mean-difference plot.
@@ -122,3 +121,56 @@ content (low counts or high variability across replicates) while the MLE
 version will show the unshrunken log2 fold change. Some contrasts, in
 particular those with interaction terms in the model, can't have their values
 shrunken for technical reasons (see the DESeq2 docs for details).
+
+### How do I interpret the functional enrichment section?
+
+Each contrast has a separate section (which you can quickly access from the
+table of contents). Each contrast's section has nested tabs.
+
+The top level of the tabs corresponds to the different databases used for
+functional enrichment analysis (e.g., GO, KEGG, Reactome etc).
+
+Each database's enrichment is available as a TSV file, in both condensed format
+(one line per term, multiple genes are separated by "/") or split (one gene per
+line; other information is duplicated). These files contain all the information
+that is plotted below. And, since the plots below only plot the top 10, 30, or
+5 categories by default, there may be a lot in these files that are not
+plotted.
+
+The second level of tabs corresponds to the different plots (described below).
+
+The analysis is visualized with 3 different plots, all showing the same results
+in different ways. For better comparison, we show each of the selected genes
+(typically, upregulated and downregulated though this can vary depending on the
+experiment) as side-by-side plots.
+
+#### dotplot
+
+This represents highly enriched terms from the analysis with the color corresponding to
+level of enrichment (adjusted p-value) and the size of the dots representing the
+number of genes associated with the GO term or pathway.
+
+This is the easiest plot to read the enriched terms. By default the top 10
+categories are shown.
+
+#### emapplot
+
+The enrichment map plot is a network visualization of the enrichment analysis. Nodes in
+the network represent GO terms or pathways and the connections (edges) between nodes
+represent shared genes between the terms/pathways. The color of the node corresponds
+to adjusted p-values, the size represent the number of genes associated with the term
+and the thickness of the edge represents the number or fraction of genes shared between
+the terms.
+
+This plot is good for identifying enriched pathways, since categories with
+similar genes will cluster together. By default the top 30 categories are
+shown.
+
+#### cnetplot
+
+This plot extracts the complex associations of genes with multiple functional terms or
+pathways. The size of the nodes for functional terms represent the number of associated
+genes and the gene nodes can also be overlayed with observed fold-changes.
+
+This plot is good for identifying which genes act as links between which
+categories. By default the top 5 categories are plotted.

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -80,6 +80,8 @@ plot.heatmap <- function(rld, colData, cols.for.grouping){
 #'
 #' @return Side effect is to plot the heatmap
 vargenes.heatmap <- function(rld, cols.for.grouping, n=50){
+  # TODO: heatmaply?
+  # TODO: allow alternative gene IDs
   topVarGenes <- head(order(rowVars(assay(rld)), decreasing=TRUE), n)
   mat <- assay(rld)[topVarGenes,]
   mat <- mat - rowMeans(mat)
@@ -96,7 +98,7 @@ vargenes.heatmap <- function(rld, cols.for.grouping, n=50){
 #'
 #' Make sure you're in an R code chunk with `results="asis"` set.
 mdcat <- function(...){
-  cat('\n', ..., '\n', sep='', fill=1500)
+  cat('\n\n', ..., ' \n\n', sep='', fill=1500)
 }
 
 

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -421,4 +421,97 @@ get.sig <- function(x, direction='up', alpha=0.1, thresh=0, return.names=TRUE){
         return(idx)
     }
 }
+
+#' Prepare list for UpSet plots, but include rownames
+#'
+#' @param x List of sets to compare (same input as to UpSetR::fromList)
+#'
+#' @return data.frame of 1 and 0 showing which genes are in which sets
+fromList.with.names <- function(lst){
+    elements <- unique(unlist(lst))
+    data <- unlist(lapply(lst, function(x) {
+        x <- as.vector(match(elements, x))
+    }))
+    data[is.na(data)] <- as.integer(0)
+    data[data != 0] <- as.integer(1)
+    data <- data.frame(matrix(data, ncol = length(lst), byrow = F))
+
+    # This is the only way in which this function differs from UpSetR::fromList
+    rownames(data) <- elements
+
+    data <- data[which(rowSums(data) != 0), ]
+    names(data) <- names(lst)
+    return(data)
+}
+
+
+#' Move rownames of data.frame to first column
+#'
+#' @param x data.frame
+#' @param name Name to use as the new first column
+#'
+#' @return data.frame with original rownames moved to new first column with
+#' optional name. rownames on the new data.frame are set to NULL.
+rownames.first.col <- function(x, name='names'){
+    orig.names <- colnames(x)
+    x <- data.frame(rownames(x), x, row.names=NULL)
+    colnames(x) <- c(name, orig.names)
+    return(x)
+}
+
+
+#' lapply over a nested list
+#'
+#' @param x Nested list. Expected 2 levels deep, and each item is the same type
+#' @param subfunc Function to apply over nested "leaf" items
+#' @param ... Additional arguments to be passed to subfunc
+#'
+#' @return Nested list with same structure but tranformed values
+nested.lapply <- function(x, subfunc, ...){
+    lapply(x, lapply, subfunc, ...)
+}
+
+#' Split clusterProfiler output into one line per gene
+#'
+#' @param x Results from clusterProfiler. It is expected that the
+#' clusterProfiler enrichment function was called with "readable=TRUE"
+#'
+#' @return data.frame with genes one per line instead of "/" separated in one
+#' line. The rest of the original line is repeated for each gene.
+#'
+split.clusterProfiler.results <- function(x){
+    df <- x@result
+    # loop over all rows
+    df.parse <- NULL
+    for(k in 1:dim(df)[1]){
+        g <- strsplit(as.character(df$geneID[k]), "/")[[1]]
+        gg <- df[rep(k, length(g)),]
+        gg$geneParse <- g
+        if(is.null(df.parse)){
+            df.parse <- gg
+        } else {
+            df.parse <- rbind(df.parse, gg)
+        }
+    }
+    return(df.parse)
+}
+
+
+#' Writes out original and split clusterprofiler results
+#'
+#' @param res clusterProfiler results
+#' @param cprof.folder Directory in which to save files. Will be created if needed.
+#' @param Label to use for the results. Will generate a filename
+#' cprof.folder/label.txt and cprof.folder/label_split.txt
+#'
+#' @return List of the two files that are created on disk.
+write.clusterprofiler.results <- function(res, cprof.folder, label){
+    dir.create(cprof.folder, showWarnings=FALSE, recursive=TRUE)
+    filename.orig <- file.path(cprof.folder, paste0(label, '.txt'))
+    write.table(res, file=filename.orig, sep='\t', quote=FALSE, row.names=FALSE)
+    filename.split <- file.path(cprof.folder, paste0(label, '_split.txt'))
+    res.split <- split.clusterProfiler.results(res)
+    write.table(res.split, file=filename.split, sep='\t', quote=FALSE, row.names=FALSE)
+    return(list(orig=filename.orig, split=filename.split))
+}
 ```

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -299,49 +299,6 @@ my.summary <- function(res, dds, alpha, ...){
    return(df)
 }
 
-#-----------------------------------------------------------------------------
-# The following are some helper functions for working with clusterProfiler results.
-# While clusterProfiler does a great job of unifying the output of different
-# enrichment metrics into a single data structure, we need a couple more things
-# for very flexibly plotting with ggplot2. These functions handle the enrichment
-# and summary of results.
-
-#' Run enrichGO on each of the three top-level ontologies
-#'
-#' @param genes Gene IDs with format matching `keytype`
-#' @param univers Universe of genes assayed
-#' @param orgdb String or OrgDb object
-#' @param keytype ID type of genes
-#"
-#' @return  List of clusterProfiler output objects, length 3 where names are
-#' ontologies (BP, MF, CC)
-clusterprofiler.enrichgo <- function(genes, universe, orgdb, keytype='ENSEMBL'){
-    lst <- list()
-    if (length(genes) > 0 ){
-        for (ont in c('BP', 'MF', 'CC')){
-            ggo <- enrichGO(gene=genes, ont=ont, universe=universe,
-                            OrgDb=orgdb, keyType=keytype, pAdjustMethod='BH',
-                            pvalueCutoff=0.01, qvalueCutoff=0.05,
-                            readable=TRUE)
-            lst[[ont]] <- ggo
-        }
-    }
-    return(lst)
-}
-
-#' Run KEGG enrichment
-#'
-#' @param genes Gene IDs typically in UniProt format
-#' @param org 3-character KEGG species ID (dme, hsa, mmu)
-#' @param keytype ID type of genes
-#'
-#' @return clusterProfiler output object
-clusterprofiler.enrichkegg <- function(genes, org, keyType='uniprot'){
-    x <- enrichKEGG(gene=genes, organism=org, keyType='uniprot',
-                    pvalueCutoff=0.05)
-    return(x)
-}
-
 #' Convert "1/100" to 0.01.
 #'
 #' clusterProfiler report columns that are strings of numbers; this converts to

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -456,32 +456,54 @@ for (name in names(res.list)){
 # UpSet plots only make sense for more than one set of genes. The Markdown
 # explanatory text and the plots themselves are only created if res.list has
 # multiple items in it.
+
 if (length(res.list) > 1){
-    mdcat("## UpSet plots")
+
+    dir.create('upset_plots', showWarnings=FALSE)
+
+    mdcat("# UpSet plots {.tabset}")
     mdcat("Gather together all the interesting gene sets into an ",
           "['UpSet' plot](http://caleydo.org/tools/upset/). These plots show ",
           "the combinatorial overlaps of genes found to be up, down, and any ",
           "changed across the different contrasts performed.")
 
-    ll <- lapply(res.list, get.sig, 'up')
+    mdcat("## Upregulated UpSet plot")
+    ll <- lapply(res.list, function (x) get.sig(x[['res']], 'up'))
     ll <- ll[lapply(ll, length) > 0]
     if (length(ll) > 1) {
-        mdcat("### Upregulated UpSet plot:")
         upset(fromList(ll), order.by='freq', nsets=length(ll))
+        outfile <- file.path('upset_plots', 'upregulated.tsv')
+        lldf <- rownames.first.col(fromList.with.names(ll))
+        write.table(lldf, file=outfile, sep='\t', row.names=FALSE)
+        mdcat('- [', outfile, ']', '(', outfile, ')')
+    } else {
+        mdcat('not enough contrasts with upregulated genes')
     }
 
-    ll <- lapply(res.list, get.sig, 'down')
+    mdcat("## Downregulated UpSet plot")
+    ll <- lapply(res.list, function (x) get.sig(x[['res']], 'down'))
     ll <- ll[lapply(ll, length) > 0]
     if (length(ll) > 1) {
-        mdcat("### Downregulated UpSet plot:")
         upset(fromList(ll), order.by='freq', nsets=length(ll))
+        outfile <- file.path('upset_plots', 'upregulated.tsv')
+        lldf <- rownames.first.col(fromList.with.names(ll))
+        write.table(lldf, file=outfile, sep='\t', row.names=FALSE)
+        mdcat('- [', outfile, ']', '(', outfile, ')')
+    } else {
+        mdcat('not enough contrasts with downregulated genes')
     }
 
-    ll <- lapply(res.list, get.sig, 'changed')
+    mdcat("## Changed genes UpSet plot")
+    ll <- lapply(res.list, function (x) get.sig(x[['res']], 'changed'))
     ll <- ll[lapply(ll, length) > 0]
     if (length(ll) > 1) {
-        mdcat("### Changed genes UpSet plot:")
         upset(fromList(ll), order.by='freq', nsets=length(ll))
+        outfile <- file.path('upset_plots', 'upregulated.tsv')
+        lldf <- rownames.first.col(fromList.with.names(ll))
+        write.table(lldf, file=outfile, sep='\t', row.names=FALSE)
+        mdcat('- [', outfile, ']', '(', outfile, ')')
+    } else {
+        mdcat('not enough contrasts with changed genes')
     }
 }
 ```

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -299,9 +299,10 @@ dds <- DESeqDataSetFromFeatureCounts(
     design=~group
 )
 
-# NOTE: If gene names came in as Ensembl "gene.version" IDs, here we split them
-# to only give the gene ID.
-rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
+if (strip.dotted.version){
+    rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
+}
+
 dds <- DESeq(dds,
     # NOTE: betaPrior
     #

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -147,6 +147,7 @@ for (col in factor.columns){
 #   you will need to edit as appropriate for your experimenal design.
 colData$group <- relevel(colData$group, ref='control')
 ```
+
 ## Experiment overview
 
 Here is the sample table with metadata used for this analysis:
@@ -156,6 +157,9 @@ knitr::kable(colData[, colnames(colData)[!colnames(colData) %in% exclude.for.pri
 ```
 
 ```{r salmon}
+# NOTE: Disable salmon?--------------------------------------------------------
+#   If you are not intending on using Salmon, set this chunk to eval=FALSE
+#
 # Load transcript-level counts
 txi <- tximport(colData[, 'salmon.path'], type='salmon', txOut=TRUE)
 transcript.tpm <- txi$abundance
@@ -166,7 +170,7 @@ colnames(transcript.tpm) <- colData$samplename
 dds.txi <- DESeqDataSetFromTximport(
     txi, colData=colData[, -grepl('path', colnames(colData)), drop=FALSE],
 
-    # NOTE: design to use when importing Salmon data.
+    # NOTE: design to use when importing Salmon data.--------------------------
     design=~group
 )
 
@@ -185,10 +189,10 @@ rld.txi <- varianceStabilizingTransformation(dds.txi, blind=TRUE)
 dds <- DESeqDataSetFromFeatureCounts(
     sampleTable=colData,
     directory='.',
-    # NOTE: What design to use?
-    #
+    # NOTE: What design to use?------------------------------------------------
     #   This object will be used for EDA, so it's recommended to use a single
-    #   factor that describes the samples
+    #   factor that describes the samples. We'll be recreating another dds
+    #   later for the actual contrasts of interest.
     design=~group)
 
 # NOTE: Gene IDs with "." in them

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -195,11 +195,9 @@ dds <- DESeqDataSetFromFeatureCounts(
     #   later for the actual contrasts of interest.
     design=~group)
 
-# NOTE: Gene IDs with "." in them
-#    If gene names came in as Ensembl "gene.version" IDs, here we split them to
-#    only give the gene ID. If you want to keep existing "." in gene names,
-#    comment out this line.
-rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
+if (strip.dotted.version){
+    rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
+}
 
 # Variance-stablilized transform to normalize gene-level counts.
 # Alternatively, use `rlog`, but that gives about the same results

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -606,8 +606,281 @@ for (name in names(ll)){
 }
 ```
 
-```{r groupcounts, cache=TRUE}
-# NOTE: optionally disable this chunk
+# Exported results
+
+```{r selections}
+sel.list <- list()
+for (name in names(res.list)){
+  res <- res.list[[name]][['res']]
+
+  # NOTE: significance level---------------------------------------------------
+  alpha <- 0.1
+
+  # NOTE: any other selections?------------------------------------------------
+  #    Here we just get the up- and downregulated genes, but any arbitrary
+  #    subsets of the results can be added.
+  #
+  #    For each selection:
+  #      - TSV of the subset of genes will be written to file and a link
+  #        created for it in the Markdown
+  #      - GO analysis will be performed on each group separately below.
+  sel.list[[name]] <- list(
+    up=res[get.sig(res, alpha=alpha, direction='up'),],
+    dn=res[get.sig(res, alpha=alpha, direction='dn'),]
+    )
+}
+
+# Keep track of our sel.list entries, here just using the last one
+sel.names <- names(sel.list[[name]])
+
+```
+
+
+# Functional enrichment analysis
+
+Here we perform gene ontology, KEGG pathway and Reactome pathway enrichment using the
+[clusterProfiler](https://bioconductor.org/packages/release/bioc/vignettes/clusterProfiler/inst/doc/clusterProfiler.html)
+package with some custom plotting functions.
+
+```{r cprof_setup, results='hide'}
+
+# output directory for clusterProfiler results
+cprof.folder <- "clusterprofiler"
+plots.folder <- "clusterprofiler/plots"
+
+# check for subfolder and create if absent
+ifelse(!dir.exists(file.path('.',cprof.folder)),
+       dir.create(file.path('.',cprof.folder), recursive = TRUE), NA)
+ifelse(!dir.exists(file.path('.',plots.folder)),
+       dir.create(file.path('.',plots.folder), recursive = TRUE), NA)
+
+# NOTE: keyTypes to obtain from bitr-------------------------------------------
+types <- c("ENTREZID","SYMBOL","UNIPROT")
+
+# NOTE: convert IDs to symbols for KEGG?---------------------------------------
+id.convert <- TRUE
+```
+
+```{r bitr_genes, results='hide'}
+# NOTE: Gene IDs are provided in what format?----------------------------------
+from.type <- "FLYBASE"
+
+deg.list <- nested.lapply(sel.list, rownames)
+genes.df <- nested.lapply(deg.list, bitr, fromType=from.type, toType=types, OrgDb=orgdb)
+```
+
+```{r enrich_all, results='hide', cache=TRUE}
+
+# run enrichment for all gene lists over a loop
+
+# NOTE: settings for clusterProfiler and plots---------------------------------
+go.keytype <- 'ENTREZID'
+kegg.keytype <- 'ncbi-geneid'
+pvalueCutoff <- 1
+qvalueCutoff <- 1
+go.uni <- NULL
+path.uni <- NULL
+kegg.organism <- 'dme'
+reactome.organism <- 'fly'
+
+
+# list to hold all enrichment results
+# will have structure:
+#
+#   all.enrich[[contrast]][[direction]][[enrichment label]]
+all.enrich <- list()
+enrich.files <- list()
+# loop over each contrast
+for(comp in names(genes.df)){
+
+    all.enrich[[comp]] <- list()
+    enrich.files[[comp]] <- list()
+
+    # loop over selection list
+    for(sel in sel.names){
+
+        all.enrich[[comp]][[sel]] <- list()
+        enrich.files[[comp]][[sel]] <- list()
+
+        gene <- genes.df[[comp]][[sel]][[go.keytype]]
+
+        for (ont in c('CC', 'BP', 'MF')){
+            go.res <- enrichGO(
+                gene=gene, universe=go.uni, keyType=go.keytype, OrgDb=orgdb,
+                ont=ont, pvalueCutoff=pvalueCutoff, qvalueCutoff=qvalueCutoff,
+                readable = TRUE)
+
+            res.label <- paste('GO', ont, sep='_')
+            all.enrich[[comp]][[sel]][[ont]] <- go.res
+            if (!is.null(go.res)){
+                enrich.files[[comp]][[sel]][[ont]] <- write.clusterprofiler.results(go.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
+            }
+        }
+
+        # perform KEGG enrichment
+        kegg.res <- enrichKEGG(
+            gene=gene, universe=path.uni, organism=kegg.organism,
+            keyType=kegg.keytype, pvalueCutoff=pvalueCutoff,
+            qvalueCutoff=qvalueCutoff)
+
+        all.enrich[[comp]][[sel]][['kegg']] <- kegg.res
+
+        if (!is.null(kegg.res)){
+            # convert uniprot IDs to readable symbols. This needs to be done separately
+            # in the case of KEGG
+            if(id.convert){
+              id.vec <- genes.df[[comp]][[sel]]$SYMBOL
+              names(id.vec) <- genes.df[[comp]][[sel]]$ENTREZID
+              kegg.res.genes <- kegg.res@result$geneID
+              for(j in 1:length(kegg.res.genes)){
+                id.split <- strsplit(kegg.res.genes[j], "/")[[1]]
+                temp <- paste(id.vec[id.split], collapse="/")
+                kegg.res@result$geneID[j] <- temp
+              }
+            }
+
+            enrich.files[[comp]][[sel]][['kegg']] <- write.clusterprofiler.results(kegg.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
+        }
+
+        # NOTE: Install OrgDb--------------------------------------------------
+        #   ReactomePA requires the relevant OrgDb package to be installed.
+        reactome.res <-enrichPathway(
+            gene=gene, universe=path.uni, organism=reactome.organism,
+            pvalueCutoff=pvalueCutoff, qvalueCutoff=qvalueCutoff, readable=TRUE)
+        all.enrich[[comp]][[sel]][['reactome']] <- reactome.res
+
+        if (!is.null(reactome.res)){
+            enrich.files[[comp]][[sel]][['reactome']] <- write.clusterprofiler.results(reactome.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
+        }
+    }
+}
+
+```
+
+```{r adjust_catlen}
+
+# This shortens the names of functional terms for better visualization
+maxcatlen <- 50
+for(comp in names(all.enrich)){
+  for(name in names(all.enrich[[comp]])){
+    for(go in names(all.enrich[[comp]][[name]])){
+      all.enrich[[comp]][[name]][[go]]@result$Description <- substr(all.enrich[[comp]][[name]][[go]]@result$Description, 1, maxcatlen)
+    }
+  }
+}
+
+```
+
+
+Below we show the results separately for each comparison: *mutant vs het*, *mutant vs wt*
+and *wt vs het*. Links to files containing analysis results are shown above each set of
+plots, with parsed files showing genes on separate lines.
+
+```{r plot_go, fig.width=15, fig.height=10, results='asis'}
+# go labels for file names
+go.label <- list(
+    BP='GO Biological Process',
+    CC='GO Cellular Component',
+    MF='GO Molecular Function',
+    kegg='KEGG Pathways',
+    reactome='Reactome Pathways')
+
+comp.label <- lapply(res.list, function (x) x[['label']])
+
+for(comp in names(all.enrich)){
+    mdcat('## ', comp.label[[comp]], ' {.tabset}')
+    for(go in names(go.label)){
+
+        mdcat('### ', go.label[[go]], ' {.tabset}')
+
+        mdcat('TSV format results (condensed and split versions):\n')
+
+        dotplots <- list()
+        emapplots <- list()
+        cnetplots <- list()
+
+        for (sel in sel.names){
+
+            res <- all.enrich[[comp]][[sel]][[go]]
+
+            if (is.null(res))
+            {
+                cat('\n\n\nNo genes enriched for:', comp, sel, go, '\n\n\n')
+                next
+            }
+
+            outfiles <- enrich.files[[comp]][[sel]][[go]]
+            f1 <- outfiles[['orig']]
+            f2 <- outfiles[['split']]
+            mdcat(' - ', sel, ' [', f1, '](', f1 ,')', ', [', f2, '](', f2 ,')')
+            title <- paste(sel, go)
+
+            # NOTE: arguments to dotplot, emapplot, and cnetplot---------------
+            #   Arguments provided are package defaults, explicitly provided
+            #   here for better visibility on what to tweak. Most commonly
+            #   adjusted is probably the showCategory argument.
+
+            dotplots[[sel]] <- dotplot(
+                res,
+                showCategory=10,
+                color='p.adjust',
+                x='GeneRatio'
+            ) +
+                ggtitle(title) +
+                theme(plot.title=element_text(hjust=0.5, size=15, face='bold'))
+
+            emapplots[[sel]] <- emapplot(
+                res,
+                showCategory=30,
+                color='p.adjust'
+            ) +
+                ggtitle(title) +
+                theme(plot.title=element_text(hjust=0.5, size=15, face='bold'))
+
+            cnetplots[[sel]] <- cnetplot(
+                res,
+                showCategory=5,
+                foldChange=NULL,
+                colorEdge=FALSE,
+                circular=FALSE,
+                node_label=TRUE
+            ) +
+                ggtitle(title) +
+                theme(plot.title=element_text(hjust=0.5, size=15, face='bold'))
+        }
+
+        save.and.link <- function(plottype){
+            f <- file.path(plots.folder, paste0(go,"_", comp,"_", plottype, ".pdf"))
+            dev.copy(pdf, file=f, width=15, height=10)
+            dev.off()
+            mdcat('Link to pdf - [', f, '](', f, ')')
+            cat('\n')
+        }
+
+        # It's possible that we got this far without any results to plot; if so
+        # then skip creating the tabs and plots
+        skip <- (length(dotplots) == 0) & (length(emapplots) == 0) & (length(cnetplots) == 0)
+
+
+        if (!skip){
+            mdcat('#### Dotplot')
+            print(plot_grid(plotlist=dotplots, align='hv'))
+            save.and.link('dotplot')
+
+            mdcat('#### Emapplot')
+            print(plot_grid(plotlist=emapplots, align='hv'))
+            save.and.link('emapplot')
+
+            mdcat('#### Cnetplot')
+            print(plot_grid(plotlist=cnetplots, align='hv'))
+            save.and.link('cnetplot')
+        }
+    }
+}
+```
+
+```{r groupcounts, cache=TRUE, eval=FALSE}
+# NOTE: optionally disable this chunk------------------------------------------
 #
 #    This chunk inspects the model matrix of the design, aggregates counts for
 #    each of the levels in the design, and attaches them to each set of
@@ -615,6 +888,7 @@ for (name in names(ll)){
 #
 #    It also attaches normalized gene counts and Salmon TPM.
 #
+#    Requires transcript.tpm to be available, and therefore Salmon was run
 counts.list <- list()
 
 # Compute aggregate (by gene) normalized transcript counts from Salmon
@@ -666,32 +940,7 @@ for (name in names(res.list)) {
 ```
 
 
-# Exported results
-
-```{r selections}
-sel.list <- list()
-for (name in names(res.list)){
-  res <- res.list[[name]][['res']]
-
-  # NOTE: significance level
-  alpha <- 0.1
-
-  # NOTE: any other selections?
-  #    Here we just get the up- and downregulated genes, but any arbitrary
-  #    subsets of the results can be added.
-  #
-  #    For each selection:
-  #      - TSV of the subset of genes will be written to file and a link
-  #        created for it in the Markdown
-  #      - GO analysis will be performed on each group separately below.
-  sel.list[[name]] <- list(
-    up=res[get.sig(res, alpha=alpha, direction='up'),],
-    dn=res[get.sig(res, alpha=alpha, direction='dn'),]
-    )
-}
-```
-
-```{r, results='asis'}
+```{r, results='asis', eval=FALSE}
 # Write out files for full and each selection, and create a link to them in the
 # HTML generated by this RMarkdown.
 for (name in names(res.list)){
@@ -710,136 +959,6 @@ for (name in names(res.list)){
 }
 ```
 
-# Gene ontology and KEGG pathway enrichment
-
-Here we perform gene ontology enrichment and KEGG pathway enrichment using the
-[clusterProfiler](https://bioconductor.org/packages/release/bioc/vignettes/clusterProfiler/inst/doc/clusterProfiler.html)
-package with some custom plotting functions.
-
-
-```{r GO, cache=TRUE}
-# NOTE: computationally intensive.
-#    clusterProfiler can take a long time to run. You may want to disable this
-#    chunk to speed things up.
-
-# Here we summarize the results into dataframes and attach additional
-# information to them such that they can be concatenated together into a large
-# tidy dataframe.
-universe <- names(dds)
-enrich.list <- list()
-for (name in names(sel.list)){
-  for (sel in names(sel.list[[name]])){
-    sel.res <- sel.list[[name]][[sel]]
-
-    # GO enrichment
-    go.label <- paste(name, sel, 'go', sep='.')
-    message(paste(go.label, '...'))
-    sg <- summarize.go(
-      clusterprofiler.enrichgo(sel.res$gene, universe, orgdb),
-      list(label=go.label, sel=sel, experiment=name))
-    if (!is.null(sg)){
-      enrich.list[[go.label]] <- sg
-    }
-
-    # KEGG enrichment
-    kegg.label <- paste(name, sel, 'kegg', sep='.')
-    message(paste(kegg.label, '...'))
-    sk <- summarize.kegg(
-      clusterprofiler.enrichkegg(sel.res$uniprot, kegg.org),
-      list(label=kegg.label, sel=sel, experiment=name))
-    if (!is.null(sk)){
-      enrich.list[[kegg.label]] <- sk
-    }
-  }
-}
-```
-
-These plots show:
-
-- enriched category (y-axis)
-- magnitude of enrichment (x-axis; plotted as -10 log10 (FDR) or "phred" scale)
-- fraction of regulated genes falling within a particular category (size)
-- experiment (color)
-- ontology (sub-panels; BP=biological process, MF=molecular function,
-  CC=cellular component, kegg=KEGG pathway)
-- direction of regulation (up- or downregulated; separate figures; labeled at the top)
-
-The plots show the top 50 terms, and are sorted by the max enrichment across
-experiments.
-
-```{r fullenrich, cache=TRUE}
-full.enrich.table <- do.call(rbind, enrich.list)
-write.table(full.enrich.table, file='functional_enrichment.tsv', row.names=FALSE, sep='\t')
-```
-
-The full analysis table can be viewed here:
-
-- [functional_enrichment.tsv](functional_enrichment.tsv)
-
-```{r, go, fig.height=15, fig.width=15, dev=c('pdf', 'png')}
-# While clusterProfiler has canned figures, it's difficult to customize them.
-# Instead, here we create a tidy dataframe of all experiments, directions, and
-# enrichment analyses so that we can plot them with ggplot2 however the
-# experiment dictates
-
-
-lim <- 50
-nchunks <- 1
-
-# NOTE: we assume that all experiments have the same selections.
-#
-#    This is the default case from the above "selections" chunk.
-for (sel in names(sel.list[[1]])){
-  mdcat('## ', sel)
-  m <- do.call(rbind, enrich.list)
-
-  # Some GO descriptions are really long. To keep the plot dimensions
-  # reasonable, we will be truncating them all to the 75th percentile.
-  length.quantile <- quantile(nchar(as.vector(m$Description, mode="character")), 0.75)
-
-  # convert to phred score, and flip the "downregulated"
-  m$phred <- -10 * log10(m$p.adjust)
-  idx <- m$sel == sel
-
-  m <- m[idx,]
-
-  if (nrow(m) == 0){next}
-
-  #replace ontology descriptions with truncations to make plot prettier
-  temp.desc <- as.vector(m$Description, mode="character")
-  needs.replacement <- which(nchar(temp.desc) > length.quantile)
-  temp.desc <- strtrim(temp.desc, length.quantile)
-  temp.desc[needs.replacement] <- paste(temp.desc[needs.replacement], "...", sep="")
-  m$Description <- factor(temp.desc)
-
-  # Grab the top (ordered by phred)
-  max.per.term <- aggregate(phred~Description, m, FUN=max)
-  o <- rev(order(max.per.term$phred))
-  m$Description <- factor(m$Description, levels=rev(max.per.term$Description[o]))
-  top.terms <- (max.per.term$Description[o][seq(lim)])
-  m.sub <- m[m$Description %in% top.terms,]
-  m.sub$Description <- droplevels(m.sub$Description)
-  levels(m.sub$Description) <- max.per.term$Description[o]
-  #m.sub <- m.sub[order(m.sub$Description),]
-
-  chunksize <- ceiling(lim / nchunks)
-  lookup <- rep(1:nchunks, each=chunksize)
-  m.sub$chunk <- 0
-  for (i in seq(length(lookup))){
-    term <- as.character(top.terms[i])
-    lab <- lookup[i]
-    m.sub$chunk[m.sub$Description == term] = lab
-  }
-
-
-print(ggplot(m.sub) +
-    geom_point(alpha=0.6) +
-    aes(y=Description, x=phred, size=frac, color=experiment) +
-    theme(text=element_text(size=12)) +
-    facet_grid(ontology~sel, scales='free_y', space='free_y')
-  )
-}
-```
 
 # Session info
 For reproducibility purposes, here is the output of `sessionInfo()` showing the
@@ -852,7 +971,7 @@ sessionInfo()
 # Help
 
 ```{r helpdocs, child="help_docs.Rmd", run_pandoc=FALSE}
-# NOTE: optional help section
+# NOTE: optional help section--------------------------------------------------
 #   Delete this chunk, or set to eval=FALSE, if you don't want to include the
 #   help text from "help_docs.Rmd"
 ```

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -718,6 +718,7 @@ for(comp in names(genes.df)){
         }
 
         # perform KEGG enrichment
+        res.label <- 'KEGG'
         kegg.res <- enrichKEGG(
             gene=gene, universe=path.uni, organism=kegg.organism,
             keyType=kegg.keytype, pvalueCutoff=pvalueCutoff,
@@ -744,6 +745,7 @@ for(comp in names(genes.df)){
 
         # NOTE: Install OrgDb--------------------------------------------------
         #   ReactomePA requires the relevant OrgDb package to be installed.
+        res.label <- 'Reactome'
         reactome.res <-enrichPathway(
             gene=gene, universe=path.uni, organism=reactome.organism,
             pvalueCutoff=pvalueCutoff, qvalueCutoff=qvalueCutoff, readable=TRUE)

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -508,7 +508,7 @@ if (length(res.list) > 1){
 }
 ```
 
-# Gene patterns
+# Gene patterns {.tabset}
 
 We can roughly group genes into expression patterns. This uses the [DEGreport
 package](https://www.bioconductor.org/packages/release/bioc/html/DEGreport.html),
@@ -517,8 +517,32 @@ which in turn uses the
 algorithm to cluster genes into similar expression patterns. The lists of genes
 found in each cluster are reported below the plot.
 
+The default general flow is as follows:
+
+```{r dpsettings}
+# NOTE: settings for DEGpatterns-----------------------------------------------
+
+# NOTE:  Max number of genes to include----------------------------------------
+#   More will be downsampled to this many
+lim <- 2000
+
+# NOTE:  Correlation coefficient above which to merge clusters-----------------
+cutoff <- 0.5
+
+# NOTE: This is set very low for test data. Default is 15.---------------------
+#   Minimum cluster size.
+minc <- 1
+```
+
+- Take the union of all genes that are changed across all contrasts
+- If there are more than `r lim` genes, randomly sample `r lim` genes (to keep the computations reasonable)
+- Cluster genes by coexpression across contrasts
+- If clusters are correlated with a correlation coefficient of `r cutoff` or
+  more, they are merged together
+- Clusters with fewer than `r minc` genes are not shown.
+
 ```{r, fig.width=12, results='asis', cache=TRUE}
-# NOTE: which genes to plot?
+# NOTE: which genes to cluster?------------------------------------------------
 #    By default, we get all the changed genes, but you may want only the up or
 #    down genes.
 ll <- lapply(res.list, function (x) get.sig(x[['res']], 'changed'))
@@ -529,13 +553,9 @@ ll <- ll[lapply(ll, length) > 0]
 for (name in names(ll)){
     genes <- ll[[name]]
 
-    # NOTE: hard limit to number of genes
-    #
-    #    Plotting more genes than this will take a lot of time to perform the
-    #    clustering.
-    #
-    #    If there are more than this limit, then we take a random sample.
-    lim <- 2000
+    # Plotting a large number of genes will take a lot of time to perform the
+    # clustering. If there are more than this limit, then we take a random
+    # sample.
     if (length(genes) > lim){
         genes <- sample(genes, lim)
     }
@@ -552,26 +572,30 @@ for (name in names(ll)){
         ma,
         colData.i,
 
-        # NOTE: "time" becomes the x-axis of the plot; change as appropriate to
-        # your experiment
+        # NOTE: xaxis of plot -------------------------------------------------
+        #   "time" argument becomes the x-axis of the plot; change as
+        #   appropriate to your experiment
         time='group',
 
-        # NOTE: reduce will merge clusters that are similar; similarity
-        # determined by cutoff
-        reduce=TRUE, cutoff=0.5,
+        # NOTE: reduce and merge cutoff----------------------------------------
+        #   Reduce will merge clusters that are similar; similarity determined
+        #   by cutoff
+        reduce=TRUE, cutoff=cutoff,
 
-        # NOTE: For more complicated designs, try the `col` argument to color
-        # the plot by another factor.
+        # NOTE: color----------------------------------------------------------
+        #   For more complicated designs, try the `col` argument to color the
+        #   plot by another factor.
         # col="another.column",
 
         # NOTE: increase min cluster size to 15
         # This is purposely set low for test data; the DEGreport default is 15.
-        minc=1
+        minc=minc
         )
 
     # In the final_clusters directory, this creates files containing lists of
     # the genes in each cluster, and adds a link to the Markdown.
     dir.create('final_clusters')
+    mdcat('\n')
     for (u in unique(d$df$cluster)){
         fn <- file.path('final_clusters',
                         paste0('final.', name, '.cluster.', u, '.txt'))

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -1,3 +1,11 @@
+---
+output:
+    html_document:
+        code_folding: hide
+        toc: true
+        toc_float: true
+        toc_depth: 3
+---
 
 ```{r, include=FALSE}
 # =============================================================================

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -304,8 +304,7 @@ if (strip.dotted.version){
 }
 
 dds <- DESeq(dds,
-    # NOTE: betaPrior
-    #
+    # NOTE: betaPrior----------------------------------------------------------
     #    betaPrior=FALSE is the default in DESeq2 >1.16, but here we set it
     #    explicitly for consistency across different versions.
     betaPrior=FALSE,
@@ -315,7 +314,12 @@ dds <- DESeq(dds,
 
 
 ```{r results, cache=TRUE}
-# NOTE: lots of editing likely needed in this chunk!
+# NOTE: lots of editing likely needed in this chunk!---------------------------
+#    This chunk builds a data structure like this:
+#
+#       res.list[[contrast]][[res]]   <- results object for this contrast
+#       res.list[[contrast]][[dds]]   <- the dds object for this contrast
+#       res.list[[contrast]][[label]] <- a nice label for this contrast
 #
 #    This is the block that performs the contrasts, filling out the `res.list`
 #    named list, which ties together the results, the DESeq object from which the
@@ -357,8 +361,7 @@ dds <- DESeq(dds,
 # use for headers and other text.
 res.list <- list()
 
-# NOTE: Example contrast #1
-#
+# NOTE: Example contrast #1----------------------------------------------------
 #   Using the example data, this compares treatment group to control group.
 #   Change to reflect your experiment.
 res.list[['all']] <- list(
@@ -368,8 +371,7 @@ res.list[['all']] <- list(
 )
 
 
-# NOTE: Example contrast #2
-#
+# NOTE: Example contrast #2----------------------------------------------------
 #    Using the example data, this compares treatment group to control group but
 #    requiring genes to have >4-fold differences (log2(4) = 2). Change to
 #    reflect your experiment.
@@ -391,11 +393,10 @@ res.list[['lfc2']] <- list(
 
 
 ```{r attach, cache=TRUE, depends='results'}
-# NOTE: Assumes Ensembl Ids
+# NOTE: Assumes Ensembl Ids----------------------------------------------------
 keytype <- 'ENSEMBL'
 
-# NOTE: Assumes that Symbol, Uniprot and alias columns are available in the
-# OrgDb
+# NOTE: Assumes these  columns are available in the OrgDb----------------------
 columns <- c('SYMBOL', 'UNIPROT', 'ALIAS')
 
 for (name in names(res.list)){
@@ -404,17 +405,9 @@ for (name in names(res.list)){
         keytype=keytype,
         columns=columns)
 }
-
-# NOTE: Assumes using ENSEMBLTRANS transcript IDs with Salmon
-#
-#   If you're using something else, you may just want to skip this step.
-transcript.geneids <- mapIds(orgdb,
-                             keys=rownames(transcript.tpm),
-                             column=keytype,
-                             keytype='ENSEMBLTRANS')
 ```
 
-# Differential expression
+# Differential expression {.tabset}
 
 Here is a table summarizing the comparisons. See the [Background and
 help](#Help) section for details.
@@ -424,18 +417,19 @@ help](#Help) section for details.
 knitr::kable(summarize.res.list(res.list, dds.list, res.list.lookup))
 ```
 
-For each comparison, we report:
+For each comparison there is a tab and under each tab are the following:
 
-- the line from the summary table for this comparison
-- counts plots for the top 3 up- and top 3 down-regulated genes
+- summary of results (the line from the summary table above for this comparison)
+- Normalized counts plots for the top 3 upregulated genes
+- Normalized counts plots for the top 3 down-regulated genes
 - an M-A plot
 - a p-value histogram
+
 
 See the [Background and help](#Help) section for details on these.
 
 ```{r, results='asis'}
-# NOTE: Which columns to add to the top plots' titles?
-#
+# NOTE: Which columns to add to the top plots' titles?-------------------------
 #    This will add nicer titles to the plots. These may have come from the
 #    `attach.info` call above.
 add_cols <- c('symbol', 'alias')
@@ -444,7 +438,7 @@ for (name in names(res.list)){
   dds.i <- res.list[[name]][['dds']]
   res.i <- res.list[[name]][['res']]
   label <- res.list[[name]][['label']]
-  mdcat('## ', label)
+  mdcat('## ', label, ' {.tabset}')
   mdcat('### Summary of results')
   print(knitr::kable(my.summary(res.i, dds.i)))
   mdcat('### Normalized counts of top 3 upregulated genes')
@@ -457,7 +451,6 @@ for (name in names(res.list)){
   pval.hist(res.i)
 }
 ```
-
 
 ```{r, fig.width=12, results='asis'}
 # UpSet plots only make sense for more than one set of genes. The Markdown

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -55,6 +55,7 @@ library(ReactomePA)
 library(cowplot)
 ```
 
+
 ```{r child='helpers.Rmd'}
 # When running interactively, run the following to load helper functions.
 # When rendering this file, the contents of this code block will be skipped
@@ -64,23 +65,22 @@ rmarkdown::render('helpers.Rmd', run_pandoc=FALSE)
 ```
 
 ```{r annotationhub_setup}
-# NOTE: try disabling this when running locally to get nicer figures:
-# options(bitmapType='cairo')
-
-# NOTE: Change these to reflect organism you're working with.
-#   e.g., 'Mus musculus', 'mmu'; 'Homo sapiens', 'hsa'. You can also provide an
-#   annotation key to override if you know the one to use, otherwise leave NA.
+# NOTE: Organism---------------------------------------------------------------
+#   This is the search term used for looking in the AnnotationHub
 annotation_genus_species <- 'Drosophila melanogaster'
-kegg.org <- 'dme'
+
+# NOTE: If you already know the key, provide it here---------------------------
+#   Provide this to override the AnnotationHub accession otherwise discovered
 annotation_key_override <- NA
 
+# This should generally not be changed unless you know what you're doing
 hub.cache <- '../../../include/AnnotationHubCache'
 
 # To ensure that we do not clobber any local copies of the annotation, we copy
-# to tmp. This also should increase performance when running on the cluster --
-# we avoid poor sqlite performance on shared filesystems by copying to
-# local scratch space.
-file.copy(hub.cache, tempdir(), recursive=TRUE)
+# to tmp. This also should increase performance when running on a cluster -- we
+# avoid poor sqlite performance on shared filesystems by copying to local
+# scratch space.
+ok <- file.copy(hub.cache, tempdir(), recursive=TRUE)
 new.cache <- file.path(tempdir(), 'AnnotationHubCache')
 
 orgdb <- get.orgdb(

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -51,6 +51,8 @@ library(clusterProfiler)
 library(AnnotationHub)
 library(BiocParallel)
 library(UpSetR)
+library(ReactomePA)
+library(cowplot)
 ```
 
 ```{r child='helpers.Rmd'}

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -681,6 +681,7 @@ qvalueCutoff <- 1
 go.uni <- NULL
 path.uni <- NULL
 kegg.organism <- 'dme'
+RUN.REACTOME <- FALSE
 reactome.organism <- 'fly'
 
 
@@ -743,16 +744,19 @@ for(comp in names(genes.df)){
             enrich.files[[comp]][[sel]][['kegg']] <- write.clusterprofiler.results(kegg.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
         }
 
-        # NOTE: Install OrgDb--------------------------------------------------
-        #   ReactomePA requires the relevant OrgDb package to be installed.
-        res.label <- 'Reactome'
-        reactome.res <-enrichPathway(
-            gene=gene, universe=path.uni, organism=reactome.organism,
-            pvalueCutoff=pvalueCutoff, qvalueCutoff=qvalueCutoff, readable=TRUE)
-        all.enrich[[comp]][[sel]][['reactome']] <- reactome.res
+        if (RUN.REACTOME) {
+            # NOTE: Install OrgDb--------------------------------------------------
+            #   ReactomePA requires the relevant OrgDb package to be installed
+            #   and so is disabled by default.
+            res.label <- 'Reactome'
+            reactome.res <-enrichPathway(
+                gene=gene, universe=path.uni, organism=reactome.organism,
+                pvalueCutoff=pvalueCutoff, qvalueCutoff=qvalueCutoff, readable=TRUE)
+            all.enrich[[comp]][[sel]][['reactome']] <- reactome.res
 
-        if (!is.null(reactome.res)){
-            enrich.files[[comp]][[sel]][['reactome']] <- write.clusterprofiler.results(reactome.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
+            if (!is.null(reactome.res)){
+                enrich.files[[comp]][[sel]][['reactome']] <- write.clusterprofiler.results(reactome.res, cprof.folder, paste0(res.label, '_', comp, '_', sel))
+            }
         }
     }
 }

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -16,12 +16,11 @@ output:
 #
 # This Rmd file aims to include "the works", with some preliminary exploratory
 # visualizations, followed by differential expression using both gene models
-# and transcript models (with examples of interaction) SVA, and some downstream
-# GO analysis.
+# and transcript models and some downstream GO analysis.
 #
 # Look for the string "NOTE:" to identify places that may need some editing.
 # Notably, the only model run by default is `~group`, which will only be
-# appropriate for the simplest experiments.
+# appropriate for the simplest experiments!
 
 # There are a fair amount of helper functions. They are stored in
 # `helpers.Rmd`, and included here as a child document so that all code is
@@ -29,24 +28,17 @@ output:
 #-----------------------------------------------------------------------------
 ```
 
-```{r, include=FALSE}
-knitr::opts_chunk$set(collapse=TRUE, warning=FALSE, message=FALSE,
-                      bootstrap.show.code=FALSE, bootstrap.show.output=FALSE,
-
-                      # try disabling this when running locally for nicer figures
-                      #dev='bitmap',
-
-                      fig.ext='png')
+```{r global_options, include=FALSE}
+knitr::opts_chunk$set(warning=FALSE, message=FALSE)
 ```
+
+# Changelog
+
+Initial results
+
+Last run: `r date()`
+
 # RNA-seq results
-
-```{r, include=FALSE}
-# NOTE: Here's a template for including a link that will load a prepared track
-# hub. It is not included by default.
-
-# [Load hub and prepared session on UCSC Genome
-# Browser](http://genome.ucsc.edu/cgi-bin/hgTracks?db=ASSEMBLY&hubUrl=https://HOST/PATH/hub.txt&hgS_loadUrlName=https://HOST/PATH/session.txt&hgS_doLoadUrl=submit&position=chr1:1-100)
-```
 
 ```{r imports}
 library(DESeq2)

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -217,8 +217,7 @@ we expect to see replicates clustering together and separation of treatments.
 ## Clustered heatmap
 
 ```{r}
-# NOTE: Which columns to use for grouping the heatmap?
-#
+# NOTE: Which columns to use for grouping the heatmap?-------------------------
 #    Add as many columns as you want for the last argument. The test data uses
 #    just the "group" column to create colored boxes corresponding to values of
 #    "group" alongside the heatmap.
@@ -226,7 +225,7 @@ we expect to see replicates clustering together and separation of treatments.
 plot.heatmap(rld, colData, c('group'))
 ```
 
-## PCA
+## PCA {.tabset}
 
 Another way of looking at sample clustering is principal components analysis
 (PCA). The x- and y-axes do not have units, rather, they represent the
@@ -234,11 +233,19 @@ dimensions along which the samples vary the most. The amount of variance
 explained by each principal component is indicated in the axes label.
 
 
-```{r}
-# NOTE: Which columns to use for grouping the heatmap?
-#
-#    See similiar note above for which columns to group by
-plotPCA(rld, intgroup=c('group'))
+```{r, results='asis'}
+# NOTE: Which columns to use for grouping the heatmap?-------------------------
+#    See similiar note above for which columns to group by. Here, each PCA plot
+#    will be in a separate tab.
+groups <- list(
+               group=c('group'),
+               layout=c('layout')
+               )
+
+for (group in groups){
+    mdcat('### ', group)
+    print(plotPCA(rld, intgroup=group))
+}
 ```
 
 
@@ -249,8 +256,7 @@ This heatmap takes the top 50 most-varying genes and plots their deviation from
 the row mean.
 
 ```{r, fig.height=12}
-# NOTE: Which columns to use for grouping the heatmap?
-#
+# NOTE: Which columns to use for grouping the heatmap?-------------------------
 #   See similiar note above for which columns to group by
 vargenes.heatmap(rld, c('group'))
 ```
@@ -271,8 +277,7 @@ knitr::kable(sf)
 ```
 
 ```{r}
-# NOTE: Run DESeq2 on multiple cores.
-#
+# NOTE: Run DESeq2 on multiple cores.------------------------------------------
 #    By default, we do not run in parallel, however this can be very useful in
 #    experiments with many samples and complex designs.  To run in parallel,
 #    comment out the line below and set cores appropriately. Then, add the
@@ -282,15 +287,14 @@ parallel <- FALSE
 ```
 
 ```{r dds_models, cache=TRUE}
-# NOTE: gene rather than transcript counts
-#
+# NOTE: gene rather than transcript counts-------------------------------------
 #    By default we use gene counts rather than transcript counts. See code
 #    above where the `dds.txi` object is created for how to modify this for
 #    transcript counts.
 dds <- DESeqDataSetFromFeatureCounts(
     sampleTable=colData,
     directory='.',
-    # NOTE: model to use
+    # NOTE: model to use-------------------------------------------------------
     #   This will be used for contrasts below.
     design=~group
 )

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -91,22 +91,31 @@ orgdb <- get.orgdb(
 ```
 
 ```{r coldata_setup}
-# NOTE: path name to sampletable
-sample.table.filename = '../config/sampletable.tsv'
+# NOTE: path name to sampletable-----------------------------------------------
+#   Path is relative to the directory of this Rmd
+sample.table.filename <- '../config/sampletable.tsv'
+
+# NOTE: Strip gene versions?---------------------------------------------------
+#   Ensembl annotations often come with ".N" version numbers at the end. If
+#   TRUE, later code will strip these off.
+strip.dotted.version <- TRUE
+
+# NOTE: Which columns to exclude from printing sampletable---------------------
+#   If you have very verbose metadata in your sampletable you can exclude those
+#   columns here.
+exclude.for.printing <- c('featurecounts.path', 'salmon.path', 'orig_filename', 'orig_filename_R2')
 
 colData <- read.table(sample.table.filename, sep='\t', header=TRUE)
 
-# NOTE: Specify which featureCounts strandedness to use.
-#
+# NOTE: Specify which featureCounts strandedness to use.-----------------------
 #   All three are created by default in the workflow, but here is where you
-#   specify which one to use for differential expression.
-
+#   specify which one to use for differential expression. This will be used to
+#   construct the paths to the correct featureCounts output files
 featurecounts.strandedness <- 's0'  # unstranded
 # featurecounts.strandedness <- 's1' # plus-strand reads correspond to sense-strand transcription (e.g., Ovation kits)
 # featurecounts.strandedness <- 's2' # minus-strand reads correspond to sense-strand transcription (e.g., TruSeq kits)
 
-# NOTE: Paths to featureCounts output.
-#
+# NOTE: Paths to featureCounts output---------------------------------------
 #   This is configured in the patterns and targets from the workflow; if you've
 #   changed anything there you will need to change it here as well.
 colData$featurecounts.path <- sapply(
@@ -117,8 +126,7 @@ colData$featurecounts.path <- sapply(
         )
     )
 
-# NOTE: Paths to Salmon output.
-#
+# NOTE: Paths to Salmon output----------------------------------------------
 #    This is configured in the patterns and targets from the workflow; if
 #    you've changed anything there you will need to change it here as well.
 colData$salmon.path <- sapply(
@@ -126,23 +134,15 @@ colData$salmon.path <- sapply(
     function (x) file.path('..', 'data', 'rnaseq_samples', x, paste0(x, '.salmon'), 'quant.sf')
 )
 
-# NOTE: Factor columns.
-#
+# NOTE: Factor columns------------------------------------------------------
 #    These are the columns in the sampletable that should be converted to
 #    factors
 factor.columns <- c('group')
-
-# NOTE: Which columns to exclude from printing.
-#
-#   If you have very verbose metadata in your sampletable you can exclude those
-#   columns here.
-exclude.for.printing <- c('featurecounts.path', 'salmon.path', 'orig_filename')
 for (col in factor.columns){
     colData[[col]] <- as.factor(colData[[col]])
 }
 
-# NOTE: Relevel the factors.
-#
+# NOTE: Relevel the factors----------------------------------------------------
 #   For the test data, "control" is the base level for the "group" factor, but
 #   you will need to edit as appropriate for your experimenal design.
 colData$group <- relevel(colData$group, ref='control')


### PR DESCRIPTION
This PR collects changes for an intended release of v1.4.

## Much-improved `rnaseq.Rmd`

- tabbed PCA plot
- improved DEGpatterns chunk
- dramatically improved functional enrichment section, with tabbed clusterprofiler plots and exported data in two flavors (combined and split)
- improved upset plots, with exported files showing sets of genes
- improved comments to highlight where to make changes
- add new helper functions to `helpers.R`:
    - `fromList.with.names`, for getting UpSet plot output
    - `rownames.first.col`, to make tidier dataframes
    - `nested.lapply`, for convenient 2-level nested list apply
    - clusterprofiler helper functions


