### PR TITLE
removed bigwig symlinking

### DIFF
--- a/test/test_configs/override.yaml
+++ b/test/test_configs/override.yaml
@@ -7,8 +7,8 @@
 #   snakemake --configfile ../../test/override.yaml --config sampletable=/path/to/tsv
 #
 merged_bigwigs:
-  control_sense:
-    sense: []
+  control_pos:
+    pos: []
   treatment_all:
-    sense: []
-    antisense: []
+    pos: []
+    neg: []

--- a/test/test_configs/star_override.yaml
+++ b/test/test_configs/star_override.yaml
@@ -3,8 +3,8 @@ aligner:
   tag: test
 
 merged_bigwigs:
-  control_sense:
-    sense: []
+  control_pos:
+    pos: []
   treatment_all:
-    sense: []
-    antisense: []
+    pos: []
+    neg: []

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -46,8 +46,6 @@ def wrapper_for(path):
 # ----------------------------------------------------------------------------
 
 
-localrules: symlink_bigwigs
-
 # See "patterns and targets" in the documentation for what's going on here.
 final_targets = utils.flatten((
     c.targets['bam'],
@@ -845,30 +843,6 @@ rule bigwig_pos:
         '&> {log}'
 
 
-rule symlink_bigwigs:
-    input:
-        pos=c.patterns['bigwig']['pos'],
-        neg=c.patterns['bigwig']['neg'],
-    output:
-        sense=c.patterns['bigwig']['sense'],
-        antisense=c.patterns['bigwig']['antisense'],
-    run:
-        # NOTE:
-        #    In our test data, reads mapping to the positive strand correspond
-        #    to sense-strand transcripts. If your protocol is reversed (e.g.,
-        #    TruSeq kits), you can map negative-strand reads to "sense". The
-        #    track hub creation in rnaseq_trackhub.py only cares about the
-        #    `sense` and `antisense` versions, so it's cheap to mess around
-        #    with the symlinking here.
-        #
-        # E.g., use this for TruSeq:
-        # utils.make_relative_symlink(input.pos, output.antisense)
-        # utils.make_relative_symlink(input.neg, output.sense)
-
-        utils.make_relative_symlink(input.pos, output.sense)
-        utils.make_relative_symlink(input.neg, output.antisense)
-
-
 rule rnaseq_rmarkdown:
     """
     Run and render the RMarkdown file that performs differential expression
@@ -892,16 +866,16 @@ rule rnaseq_rmarkdown:
 
 def bigwigs_to_merge(wc):
     chunk = config['merged_bigwigs'][wc.merged_bigwig_label]
-    antisense_labels = chunk.get('antisense', [])
-    sense_labels = chunk.get('sense', [])
-    sense_bigwigs = expand(
-        c.patterns['bigwig']['sense'],
-        sample=sense_labels
+    neg_labels = chunk.get('neg', [])
+    pos_labels = chunk.get('pos', [])
+    pos_bigwigs = expand(
+        c.patterns['bigwig']['pos'],
+        sample=pos_labels
     )
-    antisense_bigwigs = expand(
-        c.patterns['bigwig']['antisense'],
-        sample=antisense_labels)
-    return sense_bigwigs + antisense_bigwigs
+    neg_bigwigs = expand(
+        c.patterns['bigwig']['neg'],
+        sample=neg_labels)
+    return pos_bigwigs + neg_bigwigs
 
 if 'merged_bigwigs' in config:
     rule merge_bigwigs:

--- a/workflows/rnaseq/config/config.yaml
+++ b/workflows/rnaseq/config/config.yaml
@@ -34,15 +34,15 @@ fastq_screen:
     tag: test
 
 merged_bigwigs:
-  control_sense:
-    sense:
+  control_pos:
+    pos:
       - sample1
       - sample2
   treatment_all:
-    sense:
+    pos:
       - sample3
       - sample4
-    antisense:
+    neg:
       - sample3
       - sample4
 

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -44,8 +44,6 @@ rseqc:
 bigwig:
    pos: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.pos.bigwig'
    neg: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.neg.bigwig'
-   sense: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.sense.bigwig'
-   antisense: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.antisense.bigwig'
 downstream:
    rnaseq: 'downstream/rnaseq.html'
 patterns_by_aggregate:

--- a/workflows/rnaseq/rnaseq_trackhub.py
+++ b/workflows/rnaseq/rnaseq_trackhub.py
@@ -72,7 +72,7 @@ subgroups.append(
     SubGroupDefinition(
         name='strand',
         label='strand',
-        mapping={'sense': 'sense', 'antisense': 'antisense'}))
+        mapping={'pos': 'pos', 'neg': 'neg'}))
 
 
 # Identify the sort order based on the config, and create a string appropriate
@@ -91,12 +91,12 @@ composite = CompositeTrack(
     tracktype='bigWig')
 
 # ASSUMPTION: stranded bigwigs
-sense_signal_view = ViewTrack(
-    name='sensesignalviewtrack', view='sensesignal', visibility='full',
-    tracktype='bigWig', short_label='sense strand', long_label='sense strand signal')
-antisense_signal_view = ViewTrack(
-    name='antisensesignalviewtrack', view='antisensesignal', visibility='full',
-    tracktype='bigWig', short_label='antisense strand', long_label='antisense strand signal')
+pos_signal_view = ViewTrack(
+    name='possignalviewtrack', view='possignal', visibility='full',
+    tracktype='bigWig', short_label='pos strand', long_label='positive strand signal')
+neg_signal_view = ViewTrack(
+    name='negsignalviewtrack', view='negsignal', visibility='full',
+    tracktype='bigWig', short_label= 'neg strand', long_label='negative strand signal')
 
 supplemental_view = ViewTrack(
     name='suppviewtrack', view='supplementalview', visibility='full',
@@ -123,7 +123,7 @@ def decide_color(samplename):
 
 for sample in df[df.columns[0]]:
     # ASSUMPTION: stranded bigwigs
-    for direction in 'sense', 'antisense':
+    for direction in 'pos', 'neg':
 
         # ASSUMPTION: bigwig filename pattern
         bigwig = c.patterns['bigwig'][direction].format(sample=sample)
@@ -137,11 +137,11 @@ for sample in df[df.columns[0]]:
         # ASSUMPTION: stranded bigwigs
         additional_kwargs = {}
         subgroup['strand'] = direction
-        view = sense_signal_view
-        if direction == 'antisense':
+        view = pos_signal_view
+        if direction == 'neg':
             additional_kwargs['negateValues'] = 'on'
             additional_kwargs['viewLimits'] = '-25:0'
-            view = antisense_signal_view
+            view = neg_signal_view
         else:
             additional_kwargs['viewLimits'] = '0:25'
         view.add_tracks(
@@ -169,8 +169,8 @@ if supplemental:
 # Tie everything together
 composite.add_subgroups(subgroups)
 trackdb.add_tracks(composite)
-composite.add_view(sense_signal_view)
-composite.add_view(antisense_signal_view)
+composite.add_view(pos_signal_view)
+composite.add_view(neg_signal_view)
 
 # Render and upload using settings from hub config file
 hub.render()


### PR DESCRIPTION
This pull request removes the bigwig symlinking step from the workflow. This is in response to our discussion about #179 , during which we decided to scrap the symlinking and make a sort of checkpoint qc step that confirms the strandedness (among other things) before creation of the bigwigs.  The following files were modified:

- 'workflows/rnaseq/Snakefile' (removed the rule 'symlink_bigwigs')
- 'workflows/rnaseq/config/rnaseq_patterns' (removed the 'sense' and 'antisense' entries from the 'bigwig' section
-'workflows/rnaseq/config/config.yaml'  (replaced 'sense' and 'antisense' with 'pos' and 'neg' in the 'merged_bigwigs' section