### PR TITLE
rseqc infer_experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/_build
 /workflows/chipseq/Snakefile.test
 /workflows/rnaseq/Snakefile.test
 workflows/rnaseq/staging/
+env

--- a/docs/references-config.rst
+++ b/docs/references-config.rst
@@ -442,6 +442,20 @@ The following conversions can be specified for GTF files:
 
       {references_dir}/{organism}/{tag}/gtf/{organism}_{tag}.refflat
 
+:bed12:
+
+    .. code-block:: yaml
+
+        conversions:
+           - bed12
+
+   Converts GTF to BED12 format. See the ``conversion_bed12`` rule in
+   ``workflows/references/Snakefile``.
+
+   Output file::
+
+      {references_dir}/{organism}/{tag}/gtf/{organism}_{tag}.refflat
+
 :gffutils:
     Converts GTF to gffutils database (typically used for downstream work). You
     can specify arbitrary kwargs to ``gffutils.create_db`` by including them as

--- a/include/reference_configs/test.yaml
+++ b/include/reference_configs/test.yaml
@@ -13,6 +13,7 @@ references:
         postprocess: 'lib.common.gzipped'
         conversions:
           - 'refflat'
+          - 'bed12'
           - gffutils: # kwargs below will be provided to `gffutils.create_db`
               merge_strategy: 'merge'
               id_spec:

--- a/lib/common.py
+++ b/lib/common.py
@@ -410,6 +410,7 @@ def references_dict(config):
         'intergenic': '.intergenic.gtf',
         'refflat': '.refflat',
         'gffutils': '.gtf.db',
+        'bed12': '.bed12',
         'genelist': '.genelist',
         'annotation_hub': '.{keytype}.csv',
         'mappings': '.mapping.tsv.gz',

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ pytest-runner >=2.11
 pytest-xdist
 pyyaml >=3.12
 r-base >=3.5.1
+r-bindrcpp
 r-codetools
 r-dt
 r-ggrepel
@@ -56,9 +57,11 @@ r-knitr
 r-knitrbootstrap
 r-pheatmap
 r-plotly
+r-quantreg
 r-readr
 r-rmarkdown
 r-spp
+r-sparsem
 r-upsetr
 rseqc >=3.0
 salmon

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,7 @@ ucsc-bedtobigbed
 ucsc-bigwigmerge
 ucsc-fetchchromsizes
 ucsc-gtftogenepred
+ucsc-genepredtobed
 ucsc-liftover
 ucsc-oligomatch
 ucsc-twobittofa

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -178,6 +178,15 @@ rule conversion_refflat:
         '&& rm {output}.tmp '
 
 
+rule conversion_bed12:
+    input:
+        '{references_dir}/{organism}/{tag}/gtf/{organism}_{tag}.gtf'
+    output:
+        protected('{references_dir}/{organism}/{tag}/gtf/{organism}_{tag}.bed12')
+    shell:
+        'gtfToGenePred {input} {output}.tmp '
+        '&& genePredToBed {output}.tmp {output}'
+
 rule conversion_gffutils:
     """Converts a GTF into a gffutils sqlite3 database
     """

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -801,7 +801,7 @@ rule rseqc_infer_experiment:
     output:
         txt=c.patterns['rseqc']['infer_experiment']
     shell:
-        'infer_experiment.py -r {input.refflat} -i {input.bam} > {output}'
+        'infer_experiment.py -r {input.bed12} -i {input.bam} > {output}'
 
 
 rule bigwig_neg:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -791,6 +791,19 @@ rule rseqc_bam_stat:
         'bam_stat.py -i {input.bam} > {output.txt}'
 
 
+rule rseqc_infer_experiment:
+    """
+    Infer strandedness of experiment
+    """
+    input:
+        bam=c.patterns['bam'],
+        bed12=c.refdict[c.organism][config['gtf']['tag']]['bed12']
+    output:
+        txt=c.patterns['rseqc']['infer_experiment']
+    shell:
+        'infer_experiment.py -r {input.refflat} -i {input.bam} > {output}'
+
+
 rule bigwig_neg:
     """
     Create a bigwig for negative-strand reads

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -41,6 +41,7 @@ preseq: 'data/rnaseq_samples/{sample}/{sample}_preseq_c_curve.txt'
 salmon: 'data/rnaseq_samples/{sample}/{sample}.salmon/quant.sf'
 rseqc:
    bam_stat: 'data/rnaseq_samples/{sample}/rseqc/{sample}_bam_stat.txt'
+   infer_experiment: 'data/rnaseq_samples/{sample}/rseqc/{sample}_infer_experiment.txt'
 bigwig:
    pos: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.pos.bigwig'
    neg: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.neg.bigwig'


### PR DESCRIPTION
This PR adds support for RSeQC's [infer_experiment.py](http://rseqc.sourceforge.net/#infer-experiment-py) as a replacement for the featurecounts' s0, s1, s2 runs.

MultiQC picks up the infer_experiment output and puts it into a nice plot making it very easy to identify sense/antisense libraries. By the way, the existing `utils.flatten(c.targets['rseqc'])` already in the inputs of the multiqc rule doesn't need to be changes, as the new pattern/target is part of that section of the patterns yaml.

infer_experiment needed a bed12 file, so there's a new rule and a new conversion in the references workflow -- along with associated documentation.

There were some additional R packages that seemed to be missing when I was running locally so I added them, too.




