### PR TITLE
Require all SE or all PE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,15 @@ jobs:
       - *get-data
       - *rnaseq-star-step
 
+  rnaseq-sra:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *set-path
+      - *get-data
+      - *rnaseq-sra-step
+
 
   rnaseq-pe:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,14 @@ variables:
         source activate lcdb-wf-test
         pytest --doctest-modules lib
 
+  rnaseq-dryrun: &rnaseq-dryrun
+      run:
+        name: dry run
+        command: |
+          cd workflows/rnaseq
+          source activate lcdb-wf-test
+          ./run_test.sh --use-conda -n
+
   chipseq-step: &chipseq-step
       run:
         name: chipseq workflow
@@ -191,6 +199,15 @@ jobs:
       - *get-data
       - *chipseq-regression-step
 
+  rnaseq-dryrun:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *set-path
+      - *get-data
+      - *rnaseq-dryrun
+
   rnaseq:
     <<: *defaults
     steps:
@@ -303,10 +320,15 @@ workflows:
            branches:
              ignore:
                - master
+      - rnaseq-dryrun:
+         requires:
+           - initial-setup
+           - pytest
       - rnaseq:
           requires:
             - initial-setup
             - pytest
+            - rnaseq-dryrun
           filters:
             branches:
               ignore:
@@ -315,6 +337,25 @@ workflows:
           requires:
             - initial-setup
             - pytest
+            - rnaseq-dryrun
+          filters:
+            branches:
+              ignore:
+                - master
+      - rnaseq-sra:
+          requires:
+            - initial-setup
+            - pytest
+            - rnaseq-dryrun
+          filters:
+            branches:
+              ignore:
+                - master
+      - rnaseq-pe:
+          requires:
+            - initial-setup
+            - pytest
+            - rnaseq-dryrun
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,18 @@ variables:
             --configfile ../../test/test_configs/override.yaml \
             --config sampletable=../../test/test_configs/test_sra_sampletable_SE_only.tsv
 
+  rnaseq-pe-step: &rnaseq-pe-step
+      run:
+        name: rnaseq test PE
+        command: |
+          cp -r workflows/rnaseq workflows/rnaseq-pe-test
+          cd workflows/rnaseq-pe-test
+          source activate lcdb-wf-test
+
+          ./run_test.sh --use-conda -k -p -r --until multiqc \
+            --configfile ../../test/test_configs/override.yaml \
+            --config sampletable=../../test/test_configs/test_pe_sampletable.tsv
+
   colocalization-step: &colocalization-step
       run:
         name: colocalization workflow
@@ -197,6 +209,15 @@ jobs:
       - *get-data
       - *rnaseq-star-step
 
+
+  rnaseq-pe:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *set-path
+      - *get-data
+      - *rnaseq-pe-step
 
   colocalization:
     <<: *defaults

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -4,6 +4,28 @@ from itertools import product
 import pandas as pd
 from snakemake.shell import shell
 from snakemake.io import expand, regex
+from lib import common
+
+
+def detect_layout(sampletable):
+    """
+    Identifies whether a sampletable represents single-end or paired-end reads.
+
+    Raises NotImplementedError if there's a mixture.
+    """
+    is_pe = [common.is_paired_end(sampletable, s) for s in sampletable.iloc[:, 0]]
+    if all(is_pe):
+        return 'PE'
+    elif not any(is_pe):
+        return 'SE'
+    else:
+        p = sampletable.iloc[is_pe, 0].to_list()
+        s = sampletable.iloc[[not i for i in is_pe], 0].to_list()
+        if len(p) > len(s):
+            report = f'SE samples: {s}'
+        else:
+            report = f'PE samples: {p}'
+        raise ValueError(f"Only a single layout (SE or PE) is supported. {report}")
 
 
 def fill_patterns(patterns, fill, combination=product):

--- a/lib/patterns_targets.py
+++ b/lib/patterns_targets.py
@@ -62,6 +62,11 @@ class SeqConfig(object):
         self.refdict, self.conversion_kwargs = common.references_dict(self.config)
         self.organism = self.config['organism']
         self.patterns = yaml.load(open(patterns), Loader=yaml.FullLoader)
+        self.is_paired = helpers.detect_layout(self.sampletable) == 'PE'
+        if self.is_paired:
+            self.n = [1, 2]
+        else:
+            self.n = [1]
 
 
 class RNASeqConfig(SeqConfig):
@@ -86,28 +91,7 @@ class RNASeqConfig(SeqConfig):
         """
         SeqConfig.__init__(self, config, patterns, workdir)
 
-        # compose a list of samples and "n", which is either 1 or 2.
-        #
-        # Since we want to support SE and PE in the same experiment, then we
-        # can't use the standard fill method of "product" and instead need
-        # "zip". This in turn means that we need lists like:
-        #
-        #     ['sample1', 'sample1', 'sample2'], [1, 2, 1]
-        #
-        # for a case where sample1 is PE but sample 2 is SE.
-        #
-        _fill_samples = []
-        _fill_n = []
-        for sample in self.samples:
-            if common.is_paired_end(self.sampletable, sample):
-                n = [1, 2]
-            else:
-                n = [1]
-            for i in n:
-                _fill_samples.append(sample)
-                _fill_n.append(i)
-
-        self.fill = dict(sample=_fill_samples, n=_fill_n)
+        self.fill = dict(sample=self.samples, n=self.n)
         self.patterns_by_aggregation = self.patterns.pop('patterns_by_aggregate', None)
         self.targets = helpers.fill_patterns(self.patterns, self.fill, zip)
 
@@ -161,7 +145,7 @@ class ChIPSeqConfig(SeqConfig):
         # First, the samples...
         self.patterns_by_sample = self.patterns['patterns_by_sample']
         self.fill_by_sample = dict(
-            n=[1,2],
+            n=self.n,
             sample=self.samples.values,
             label=self.sampletable.label.values,
             ip_label=self.sampletable.label[

--- a/test/test_configs/test_pe_sampletable.tsv
+++ b/test/test_configs/test_pe_sampletable.tsv
@@ -1,0 +1,2 @@
+samplename	group	layout	orig_filename	orig_filename_R2
+sample1pe	control	PE	data/example_data/rnaseq_sample1PE_1.fq.gz	data/example_data/rnaseq_sample1PE_2.fq.gz

--- a/test/test_configs/test_sra_sampletable.tsv
+++ b/test/test_configs/test_sra_sampletable.tsv
@@ -1,4 +1,3 @@
 samplename	Run	layout
-sra1	SRR948304	SINGLE
 sra2	SRR948304	PAIRED
 sra3	SRR948305	PAIRED

--- a/test/test_configs/two_samples.tsv
+++ b/test/test_configs/two_samples.tsv
@@ -1,3 +1,3 @@
-samplename	group	layout	orig_filename	orig_filename_R2
-sample1	control	PE	data/example_data/rnaseq_sample1PE_1.fq.gz	data/example_data/rnaseq_sample1PE_2.fq.gz
-sample2	control	SE	data/example_data/rnaseq_sample2.fq.gz	
+samplename	group	layout	orig_filename
+sample1	control	SE	data/example_data/rnaseq_sample1PE_1.fq.gz
+sample2	control	SE	data/example_data/rnaseq_sample2.fq.gz

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -310,11 +310,6 @@ rule rRNA:
         bam=c.patterns['rrna']['bam']
     log:
         c.patterns['rrna']['bam'] + '.log'
-    params:
-        # NOTE: we'd likely only want to report a single alignment for rRNA
-        # screening
-        bowtie2_extra='-k 1',
-        samtools_view_extra='-F 0x04'
     threads: 6
     run:
         prefix = aligners.prefix_from_bowtie2_index(input.index)

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -754,8 +754,11 @@ rule rseqc_infer_experiment:
         bed12=c.refdict[c.organism][config['gtf']['tag']]['bed12']
     output:
         txt=c.patterns['rseqc']['infer_experiment']
+    log:
+        c.patterns['rseqc']['infer_experiment'] + '.log'
+
     shell:
-        'infer_experiment.py -r {input.bed12} -i {input.bam} > {output}'
+        'infer_experiment.py -r {input.bed12} -i {input.bam} > {output} &> {log}'
 
 
 rule bigwig_neg:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -70,14 +70,12 @@ final_targets = utils.flatten((
 if 'merged_bigwigs' in config:
     final_targets.extend(utils.flatten(c.targets['merged_bigwig']))
 
-# Special case: all samples are single-end
-if all(c.sampletable.iloc[:, 0].apply(
-    lambda x: not common.is_paired_end(c.sampletable, x))
-):
-    ALL_SE = True
-    final_targets = [i.replace('{n}', '1') for i in final_targets]
-else:
-    ALL_SE = False
+
+def render_r1_r2(pattern, r1_only=False):
+    return expand(pattern, sample='{sample}', n=c.n)
+
+def r1_only(pattern):
+    return expand(pattern, sample='{sample}', n=1)
 
 rule targets:
     """
@@ -96,15 +94,9 @@ if 'orig_filename' in c.sampletable.columns:
         Given a sample, returns either one or two original fastq files
         depending on whether the library was single- or paired-end.
         """
-        row = _st.loc[wc.sample]
-        res = [row['orig_filename']]
-        try:
-            r2 = row['orig_filename_R2']
-            if isinstance(r2, str):
-                res.append(row['orig_filename_R2'])
-        except KeyError:
-            pass
-        return res
+        if c.is_paired:
+            return _st.loc[wc.sample, ['orig_filename', 'orig_filename_R2']]
+        return _st.loc[wc.sample, ['orig_filename']]
 
 
     rule symlinks:
@@ -114,30 +106,16 @@ if 'orig_filename' in c.sampletable.columns:
         input:
             orig_for_sample
         output:
-            c.patterns['fastq']
-        wildcard_constraints:
-            n="\d+"
+            render_r1_r2(c.patterns['fastq'])
         run:
 
-            assert len(output) == 1
-            if wildcards.n == '1':
-                src = input[0]
-            elif wildcards.n == '2':
-                src = input[1]
-            else:
-                raise ValueError("n={}, only 1 and 2 supported".format(wildcards.n))
-
-            utils.make_relative_symlink(src, output[0])
+            assert len(output) == len(input), (input, output)
+            for src, linkname in zip(input, output):
+                utils.make_relative_symlink(src, linkname)
 
 
     rule symlink_targets:
         input: c.targets['fastq']
-
-
-def render_r1_r2(pattern):
-    if ALL_SE:
-        return expand(pattern, sample='{sample}', n=[1])
-    return expand(pattern, sample='{sample}', n=[1, 2])
 
 
 if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('SRR')) > 0:
@@ -155,8 +133,7 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
             # Two different paths depending on the layout. In both cases, we
             # want to avoid creating the final output until the very end, to
             # avoid incomplete downloads.
-            if common.is_paired_end(c.sampletable, wildcards.sample):
-
+            if c.is_paired:
                 # For PE we need to use --split-files, which also means using
                 # the slower --gzip
                 shell(
@@ -167,7 +144,7 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
                     # '-X 100000 ' # [TEST SETTINGS]
                 )
 
-                # The filenames are predictable, so we can move them as needd.
+                # The filenames are predictable, so we can move them as needed.
                 shell('mv {srr}_1.fastq.gz {output[0]}')
                 shell('mv {srr}_2.fastq.gz {output[1]}')
 
@@ -182,8 +159,6 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
                     '| gzip -c > {output[0]}.tmp '
                     '&& mv {output[0]}.tmp {output[0]} '
                 )
-                if not ALL_SE:
-                    shell('touch {output[1]}')
 
 
 rule cutadapt:
@@ -191,19 +166,16 @@ rule cutadapt:
     Run cutadapt
     """
     input:
-        fastq=common.fill_r1_r2(c.sampletable, c.patterns['fastq'])
+        fastq=render_r1_r2(c.patterns['fastq'])
     output:
         fastq=render_r1_r2(c.patterns['cutadapt'])
     log:
         render_r1_r2(c.patterns['cutadapt'])[0] + '.log'
     threads: 6
     run:
-        paired = len(input) == 2
 
         # NOTE: Change cutadapt params here
-
-
-        if paired:
+        if c.is_paired:
             shell(
                 "cutadapt "
                 "{input.fastq[0]} "
@@ -227,8 +199,6 @@ rule cutadapt:
                 '--minimum-length 25 '
                 "&> {log}"
             )
-            if not ALL_SE:
-                shell('touch {output[1]}')
 
 
 rule fastqc:
@@ -260,12 +230,12 @@ if config['aligner']['index'] == 'hisat2':
             prefix = aligners.prefix_from_bowtie2_index(input.index)
             sam = output.bam.replace('.bam', '.sam')
 
-            # If two fastqs were provided, assume paired-end mode; otherwise single-end
-            if isinstance(input.fastq, str) or len(input.fastq) == 1:
-                fastqs = '-U {0} '.format(input.fastq)
-            else:
+            if c.is_paired:
                 assert len(input.fastq) == 2
                 fastqs = '-1 {0} -2 {1} '.format(*input.fastq)
+            else:
+                assert len(input.fastq) == 1
+                fastqs = '-U {0} '.format(input.fastq)
 
             shell(
                 "hisat2 "
@@ -334,7 +304,7 @@ rule rRNA:
     Map reads with bowtie2 to the rRNA reference
     """
     input:
-        fastq=common.fill_r1_r2(c.sampletable, c.patterns['cutadapt'], r1_only=True),
+        fastq=r1_only(c.patterns['cutadapt']),
         index=[c.refdict[c.organism][config['rrna']['tag']]['bowtie2']]
     output:
         bam=c.patterns['rrna']['bam']
@@ -421,7 +391,7 @@ rule fastq_screen:
     """
     input:
         **fastq_screen_references(),
-        fastq=common.fill_r1_r2(c.sampletable, rules.cutadapt.output.fastq, r1_only=True),
+        fastq=r1_only(rules.cutadapt.output.fastq),
     output:
         txt=c.patterns['fastq_screen']
     log:
@@ -442,21 +412,25 @@ rule featurecounts:
         counts='{sample_dir}/rnaseq_aggregation/featurecounts.txt'
     log:
         '{sample_dir}/rnaseq_aggregation/featurecounts.txt.log'
-    shell:
+    run:
+        # NOTE: By default, we use -p for paired-end
+        p_arg = ''
+        if c.is_paired:
+            p_arg = '-p '
+        shell(
             'featureCounts '
 
             # NOTE:
-            # Choose strandedness here
+            # Choose strandedness here (s0 is unstranded, s1 is sense, s2 is
+            # antisense)
             '-s0 '
-
-            # NOTE:
-            # Paired-end data? You'll likely want to use the -p argument
-            # '-p '
+            '{p_arg} '
             '-T {threads} '
             '-a {input.annotation} '
             '-o {output.counts} '
             '{input.bam} '
             '&> {log}'
+        )
 
 
 rule rrna_libsizes_table:
@@ -603,6 +577,7 @@ rule multiqc:
             '&> {log} '
         )
 
+
 rule markduplicates:
     """
     Mark or remove PCR duplicates with Picard MarkDuplicates
@@ -722,8 +697,7 @@ rule salmon:
         c.patterns['salmon'] + '.log'
     threads: 6
     run:
-        paired = len(input.fastq) == 2
-        if paired:
+        if c.is_paired:
             shell(
                 # NOTE: adjust Salmon params as needed
                 'salmon quant '

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -782,6 +782,10 @@ rule bigwig_neg:
         '--minMappingQuality 20 '
         '--ignoreDuplicates '
         '--smoothLength 10 '
+
+        # NOTE: --filterRNAstrand forward keeps minus-strand reads, which
+        # originally came from genes on the forward strand assuming
+        # a dUTP-based library prep.
         '--filterRNAstrand forward '
         '--normalizeUsing BPM '
         '&> {log}'
@@ -808,6 +812,10 @@ rule bigwig_pos:
         '--minMappingQuality 20 '
         '--ignoreDuplicates '
         '--smoothLength 10 '
+
+        # NOTE: --filterRNAstrand reverse keeps plus-strand reads, which
+        # originally came from genes on the reverse strand assuming
+        # a dUTP-based library prep.
         '--filterRNAstrand reverse '
         '--normalizeUsing BPM '
         '&> {log}'

--- a/workflows/rnaseq/config/sampletable.tsv
+++ b/workflows/rnaseq/config/sampletable.tsv
@@ -1,5 +1,5 @@
-samplename	group	layout	orig_filename	orig_filename_R2
-sample1	control	PE	data/example_data/rnaseq_sample1PE_1.fq.gz	data/example_data/rnaseq_sample1PE_2.fq.gz
-sample2	control	SE	data/example_data/rnaseq_sample2.fq.gz	
-sample3	treatment	SE	data/example_data/rnaseq_sample3.fq.gz	
-sample4	treatment	SE	data/example_data/rnaseq_sample4.fq.gz	
+samplename	group	layout	orig_filename
+sample1	control	SE	data/example_data/rnaseq_sample1PE_1.fq.gz
+sample2	control	SE	data/example_data/rnaseq_sample2.fq.gz
+sample3	treatment	SE	data/example_data/rnaseq_sample3.fq.gz
+sample4	treatment	SE	data/example_data/rnaseq_sample4.fq.gz


### PR DESCRIPTION
Addresses #175 by removing support for experiments where some samples are SE and some samples are PE.

As described in #175, supporting such mixed layouts was over-complicating the code with marginal benefit.

This PR:

- adds a `is_paired` attribute to SeqConfig objects (plus requisite infrastructure to do so)
- updates RNA-seq snakefile to pay attention to the new attribute, while simplifying other code
- raises ValueError and prints the sample names that are inconsistent (chooses to report SE or PE consistencies based on which is smaller to avoid spamming stdout with many samples)
- reenables the SRA test
- adds a separate PE test (and corresponding sampletable)
- RNA-seq tests will only run if the dry-run test works, which should hopefully short-circuit spurious tests on circle-ci.