### PR TITLE
tests use results from deploy script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ variables:
         source activate lcdb-wf-test
 
         # container has a default python of 2.6, and we're using argparse.
-        python deploy.py --flavor full /tmp/lcdb-wf-test
+        python deploy.py --flavor full --dest /tmp/lcdb-wf-test
         cp workflows/chipseq/run_test.sh /tmp/lcdb-wf-test/workflows/chipseq
         cp workflows/rnaseq/run_test.sh /tmp/lcdb-wf-test/workflows/rnaseq
         cp workflows/references/run_test.sh /tmp/lcdb-wf-test/workflows/references

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ variables:
         cp workflows/rnaseq/run_test.sh /tmp/lcdb-wf-test/workflows/rnaseq
         cp workflows/references/run_test.sh /tmp/lcdb-wf-test/workflows/references
         cp workflows/colocalization/run_test.sh /tmp/lcdb-wf-test/workflows/colocalization
+        cp ci/get-data.py /tmp/lcdb-wf-test/ci/
         cd /tmp/lcdb-wf-test
         python ci/get-data.py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,16 +50,23 @@ variables:
       name: Download example data
       command: |
         yum install -yy rsync
+        # container has a default python of 2.6, and we're using argparse, so
+        # we need to use the environment.
         source activate lcdb-wf-test
 
-        # container has a default python of 2.6, and we're using argparse.
-        python deploy.py --flavor full --dest /tmp/lcdb-wf-test
-        cp workflows/chipseq/run_test.sh /tmp/lcdb-wf-test/workflows/chipseq
-        cp workflows/rnaseq/run_test.sh /tmp/lcdb-wf-test/workflows/rnaseq
-        cp workflows/references/run_test.sh /tmp/lcdb-wf-test/workflows/references
-        cp workflows/colocalization/run_test.sh /tmp/lcdb-wf-test/workflows/colocalization
-        cp ci/get-data.py /tmp/lcdb-wf-test/ci/
-        cd /tmp/lcdb-wf-test
+        # Note that $DEPLOY is set in the "set-paths" step configured below.
+        python deploy.py --flavor full --dest $DEPLOY
+
+        # Separately copy over some test-specific files
+        cp workflows/chipseq/run_test.sh $DEPLOY/workflows/chipseq
+        cp workflows/rnaseq/run_test.sh $DEPLOY/workflows/rnaseq
+        cp workflows/colocalization/run_test.sh $DEPLOY/workflows/references
+        cp workflows/colocalization/run_test.sh $DEPLOY/workflows/colocalization
+        mkdir $DEPLOY/ci
+        cp ci/get-data.py $DEPLOY/ci
+
+        # download example data
+        cd $DEPLOY
         python ci/get-data.py
 
   pytest-step: &pytest-step
@@ -73,7 +80,7 @@ variables:
       run:
         name: dry run
         command: |
-          cd /tmp/lcdb-wf-test/workflows/rnaseq
+          cd $DEPLOY/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -n
 
@@ -81,7 +88,7 @@ variables:
       run:
         name: chipseq workflow
         command: |
-          cd /tmp/lcdb-wf-test/workflows/chipseq
+          cd $DEPLOY/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -91,7 +98,7 @@ variables:
         name: chipseq regression test workflow
         command: |
           ORIG=$(pwd)
-          cd /tmp/lcdb-wf-test/workflows/chipseq
+          cd $DEPLOY/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r \
             --configfile $ORIG/test/test_configs/test_chipseq_regression.yaml \
@@ -103,7 +110,7 @@ variables:
       run:
         name: references workflow
         command: |
-          cd /tmp/lcdb-wf-test/workflows/references
+          cd $DEPLOY/workflows/references
           source activate lcdb-wf-test
           ./run_test.sh  --use-conda -j2 -k -p -r
 
@@ -111,7 +118,7 @@ variables:
       run:
         name: rnaseq workflow
         command: |
-          cd /tmp/lcdb-wf-test/workflows/rnaseq
+          cd $DEPLOY/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -121,7 +128,7 @@ variables:
         name: rnaseq star aligner
         command: |
           ORIG=$(pwd)
-          cd /tmp/lcdb-wf-test
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-star
           cd workflows/rnaseq-star
           source activate lcdb-wf-test
@@ -136,7 +143,7 @@ variables:
         name: rnaseq download from SRA
         command: |
           ORIG=$(pwd)
-          cd /tmp/lcdb-wf-test
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-sra-test
           cd workflows/rnaseq-sra-test
           source activate lcdb-wf-test
@@ -154,7 +161,7 @@ variables:
         name: rnaseq test PE
         command: |
           ORIG=$(pwd)
-          cd /tmp/lcdb-wf-test
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-pe-test
           cd workflows/rnaseq-pe-test
           source activate lcdb-wf-test
@@ -167,7 +174,7 @@ variables:
       run:
         name: colocalization workflow
         command: |
-          cd /tmp/lcdb-wf-test/workflows/colocalization
+          cd $DEPLOY/workflows/colocalization
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
 
@@ -177,6 +184,7 @@ variables:
         name: Set path
         command: |
           echo 'export PATH=$PATH:/root/project/miniconda/bin' >> $BASH_ENV
+          echo 'export DEPLOY=/tmp/lcdb-wf-test' >> $BASH_ENV
           source $BASH_ENV
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ variables:
     run:
       name: Download example data
       command: |
+        apt-get install -yy rsync
         source activate lcdb-wf-test
 
         # container has a default python of 2.6, and we're using argparse.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ variables:
     run:
       name: Download example data
       command: |
-        apt-get install -yy rsync
+        yum install -yy rsync
         source activate lcdb-wf-test
 
         # container has a default python of 2.6, and we're using argparse.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,15 @@ variables:
     run:
       name: Download example data
       command: |
+        source activate lcdb-wf-test
+
+        # container has a default python of 2.6, and we're using argparse.
         python deploy.py --flavor full /tmp/lcdb-wf-test
         cp workflows/chipseq/run_test.sh /tmp/lcdb-wf-test/workflows/chipseq
         cp workflows/rnaseq/run_test.sh /tmp/lcdb-wf-test/workflows/rnaseq
         cp workflows/references/run_test.sh /tmp/lcdb-wf-test/workflows/references
         cp workflows/colocalization/run_test.sh /tmp/lcdb-wf-test/workflows/colocalization
         cd /tmp/lcdb-wf-test
-        source activate lcdb-wf-test
         python ci/get-data.py
 
   pytest-step: &pytest-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ variables:
         cp workflows/colocalization/run_test.sh $DEPLOY/workflows/colocalization
         mkdir $DEPLOY/ci
         cp ci/get-data.py $DEPLOY/ci
+        cp ci/preprocessor.py $DEPLOY/ci
 
         # download example data
         cd $DEPLOY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ variables:
     run:
       name: Download example data
       command: |
+        python deploy.py --flavor full /tmp/lcdb-wf-test
+        cp workflows/chipseq/run_test.sh /tmp/lcdb-wf-test/workflows/chipseq
+        cp workflows/rnaseq/run_test.sh /tmp/lcdb-wf-test/workflows/rnaseq
+        cp workflows/references/run_test.sh /tmp/lcdb-wf-test/workflows/references
+        cp workflows/colocalization/run_test.sh /tmp/lcdb-wf-test/workflows/colocalization
+        cd /tmp/lcdb-wf-test
         source activate lcdb-wf-test
         python ci/get-data.py
 
@@ -63,7 +69,7 @@ variables:
       run:
         name: dry run
         command: |
-          cd workflows/rnaseq
+          cd /tmp/lcdb-wf-test/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -n
 
@@ -71,7 +77,7 @@ variables:
       run:
         name: chipseq workflow
         command: |
-          cd workflows/chipseq
+          cd /tmp/lcdb-wf-test/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -80,11 +86,12 @@ variables:
       run:
         name: chipseq regression test workflow
         command: |
-          cd workflows/chipseq
+          ORIG=$(pwd)
+          cd /tmp/lcdb-wf-test/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r \
-            --configfile ../../test/test_configs/test_chipseq_regression.yaml \
-            --config sampletable=../../test/test_configs/chipseq_one_run.tsv \
+            --configfile $ORIG/test/test_configs/test_chipseq_regression.yaml \
+            --config sampletable=$ORIG/test/test_configs/chipseq_one_run.tsv \
             --config merged_bigwigs="{}" \
             --until bed_to_bigbed
 
@@ -92,7 +99,7 @@ variables:
       run:
         name: references workflow
         command: |
-          cd workflows/references
+          cd /tmp/lcdb-wf-test/workflows/references
           source activate lcdb-wf-test
           ./run_test.sh  --use-conda -j2 -k -p -r
 
@@ -100,7 +107,7 @@ variables:
       run:
         name: rnaseq workflow
         command: |
-          cd workflows/rnaseq
+          cd /tmp/lcdb-wf-test/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -109,48 +116,54 @@ variables:
       run:
         name: rnaseq star aligner
         command: |
+          ORIG=$(pwd)
+          cd /tmp/lcdb-wf-test
           cp -r workflows/rnaseq workflows/rnaseq-star
           cd workflows/rnaseq-star
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -k -p -r \
             --forcerun star \
-            --configfile ../../test/test_configs/star_override.yaml \
-            --config sampletable=../../test/test_configs/two_samples.tsv \
+            --configfile $ORIG/test/test_configs/star_override.yaml \
+            --config sampletable=$ORIG/test/test_configs/two_samples.tsv \
             --until star
 
   rnaseq-sra-step: &rnaseq-sra-step
       run:
         name: rnaseq download from SRA
         command: |
+          ORIG=$(pwd)
+          cd /tmp/lcdb-wf-test
           cp -r workflows/rnaseq workflows/rnaseq-sra-test
           cd workflows/rnaseq-sra-test
           source activate lcdb-wf-test
 
           ./run_test.sh --use-conda -k -p -r --until cutadapt \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_sra_sampletable.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_sra_sampletable.tsv
 
           ./run_test.sh --use-conda -k -p -r --until cutadapt \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_sra_sampletable_SE_only.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_sra_sampletable_SE_only.tsv
 
   rnaseq-pe-step: &rnaseq-pe-step
       run:
         name: rnaseq test PE
         command: |
+          ORIG=$(pwd)
+          cd /tmp/lcdb-wf-test
           cp -r workflows/rnaseq workflows/rnaseq-pe-test
           cd workflows/rnaseq-pe-test
           source activate lcdb-wf-test
 
           ./run_test.sh --use-conda -k -p -r --until multiqc \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_pe_sampletable.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_pe_sampletable.tsv
 
   colocalization-step: &colocalization-step
       run:
         name: colocalization workflow
         command: |
-          cd workflows/colocalization
+          cd /tmp/lcdb-wf-test/workflows/colocalization
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
 

--- a/deploy.py
+++ b/deploy.py
@@ -4,6 +4,8 @@ import argparse
 import subprocess as sp
 import datetime
 import json
+import fnmatch
+
 
 HERE = os.path.dirname(__file__)
 
@@ -22,11 +24,17 @@ up-to-date.
 """
 
 ap = argparse.ArgumentParser(usage=usage)
-ap.add_argument('--flavor', default='full', help='''Options are rnaseq, chipseq, colocalization, full. Default is full.''')
+ap.add_argument('--flavor', default='full', help='''Options are rnaseq,
+                chipseq, colocalization, full. Default is full.''')
 ap.add_argument('--dest', help='''Destination directory in which to copy files''')
+ap.add_argument('--build-env', action='store_true', help='''If specified,
+a conda environment with all dependencies will be installed into a directory
+                called "env" within the directory provided for --dest.  ''')
+
 args = ap.parse_args()
 dest = args.dest
 flavor = args.flavor
+
 
 flavors = {
     'all': {
@@ -35,68 +43,110 @@ flavors = {
             'include',
             'lib',
             'requirements.txt',
+            '.gitignore',
         ],
         'exclude': [
-            'wrappers/wrappers/demo',
-            'workflows/*/run_test.sh',
 
-            # The following files to exclude are those that are created from
-            # a test run.
-            'lib/__pycache__',
-            'lib/postprocess/__pycache__',
+            '.buildkite/*',
+            'ci/*',
+            '.circleci/*',
+            'config/*',
+            'deploy.py',
+            'docs/*',
             'include/AnnotationHubCache',
-            'workflows/*/Snakefile.test',
-            'workflows/*/references_data',
-            'workflows/*/.snakemake',
+            'lib/postprocess/__pycache__',
+            'lib/__pycache__',
+            '*/.pytest_cache/*',
+            'README.md',
+            'test/*',
+            '.travis.yml',
+            'workflows/colocalization/results',
             'workflows/*/data',
+            'workflows/figures/*',
+            'workflows/*/references_data',
+            'workflows/*/references_dir',
+            'workflows/*/reports',
+            'workflows/rnaseq/downstream/final_clusters',
+            'workflows/rnaseq/downstream/*html',
+            'workflows/rnaseq/downstream/*log',
             'workflows/rnaseq/downstream/rnaseq_cache',
             'workflows/rnaseq/downstream/rnaseq_files',
-            'workflows/rnaseq/downstream/final_clusters',
             'workflows/rnaseq/downstream/*.tsv*',
-            'workflows/rnaseq/downstream/*log',
-            'workflows/rnaseq/downstream/*html',
-            'workflows/colocalization/results',
+            'workflows/*/run_test.sh',
+            'workflows/*/Snakefile.test',
+            'workflows/*/.snakemake',
+            'wrappers/demo/*',
+            'wrappers/test/*',
+            'wrappers/test_toy.py',
+
         ],
     },
     'chipseq': [
-        'workflows/chipseq',
-        'workflows/references',
+        'workflows/chipseq/*',
+        'workflows/references/*',
     ],
     'rnaseq': [
-        'workflows/rnaseq',
-        'workflows/rnaseq/downstream/',
-        'workflows/references',
+        'workflows/rnaseq/*',
+        'workflows/rnaseq/downstream/*',
+        'workflows/references/*',
     ],
     'colocalization': [
-        'workflows/colocalization',
+        'workflows/colocalization/*',
     ],
 
     'full': [
-        'workflows',
+        'workflows/*',
     ],
 }
 
-paths = set(flavors['all']['include'])
-paths = paths | set(flavors[flavor])
+
+under_version_control = sorted(sp.check_output(
+    [ 'git', 'ls-tree', '-r', 'HEAD', '--name-only'],
+    universal_newlines=True).splitlines(False))
+
+
+def filter_out_excluded(filenames, patterns_to_exclude):
+    keep = []
+    for filename in filenames:
+        if not any(fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_exclude):
+            keep.append(filename)
+    return keep
+
+def filter_out_other_workflows(filenames, patterns_to_include, prefix='workflows'):
+    keep = []
+    for filename in filenames:
+        if not filename.startswith(prefix):
+            keep.append(filename)
+            continue
+        if any(fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_include):
+            keep.append(filename)
+    return keep
+
+keep = filter_out_excluded(under_version_control, flavors['all']['exclude'])
+
+keep = filter_out_other_workflows(keep, flavors[flavor])
 
 exclude = tempfile.NamedTemporaryFile(delete=False).name
+exclude = '.exclude'
 with open(exclude, 'w') as fout:
     fout.write('\n'.join(flavors['all']['exclude']))
 
 include = tempfile.NamedTemporaryFile(delete=False).name
+include = '.include'
 with open(include, 'w') as fout:
-    fout.write('\n'.join(paths) + '\n')
-
+    fout.write('\n\n')
+    fout.write('\n'.join(keep) + '\n')
 
 sp.check_call([
     'rsync',
     '--relative',
+    '-v',
     '-ar',
+    '--progress',
     '--files-from={}'.format(include),
     '--exclude-from={}'.format(exclude),
     HERE,
     dest])
-
 
 commit, message = sp.check_output(
     ['git', 'log', '--oneline', '-1'],
@@ -127,3 +177,10 @@ log = os.path.join(dest, '.lcdb-wf-deployment.json')
 with open(log, 'w') as fout:
     fout.write(json.dumps(d) + '\n')
 os.chmod(log, 0o440)
+
+if args.build_env:
+    sp.check_call(
+        ['conda', 'create', '-y', '-p', './env', '--file', 'requirements.txt', '-c',
+         'conda-forge', '-c', 'bioconda', '-c', 'defaults'],
+        universal_newlines=True,
+        cwd=dest)

--- a/deploy.py
+++ b/deploy.py
@@ -23,185 +23,212 @@ used and the timestamp. This can be used to compare changes and stay
 up-to-date.
 """
 
+
+# Notes on include/exclude patterns for rsync:
+#
+# - Excluding a directory excludes everything below it
+# - Including a directory does not automatically include everything below it.
+# - Use "dir/***" to include everything
+# - Patterns with no / applies to basename
+# - Patterns ending with / implies directories only
+# - Patterns starting with / implies that the root is the source dir provided to rsync
+# - * is anything but /
+# - ** is any part of path, including /
+always = {
+    "include": [
+        "wrappers/wrappers",
+        "include",
+        "lib",
+        "requirements.txt",
+        ".gitignore",
+    ],
+    "exclude": [
+        "sra_sampletable.tsv",
+        "/.buildkite/*",
+        "/ci/*",
+        "/.circleci/*",
+        "/config/*",
+        "/deploy.py",
+        "/docs/***",
+        "/include/AnnotationHubCache",
+        "/lib/postprocess/__pycache__",
+        "/lib/__pycache__",
+        "*/.pytest_cache/*",
+        "/README.md",
+        "/test/***",
+        "/.travis.yml",
+        "/workflows/*/results",
+        "/workflows/*/data",
+        "/workflows/figures/*",
+        "/workflows/*/references_data",
+        "/workflows/*/references_dir",
+        "/workflows/*/reports",
+        "/workflows/rnaseq/downstream/final_clusters",
+        "/workflows/rnaseq/downstream/*html",
+        "/workflows/rnaseq/downstream/*log",
+        "/workflows/rnaseq/downstream/rnaseq_cache",
+        "/workflows/rnaseq/downstream/rnaseq_files",
+        "/workflows/rnaseq/downstream/*.tsv*",
+        "/workflows/*/run_test.sh",
+        "/workflows/*/Snakefile.test",
+        "/workflows/*/.snakemake",
+        "/wrappers/demo/*",
+        "/wrappers/test/*",
+        "/wrappers/test_toy.py",
+    ],
+}
+
+flavors = {
+    "chipseq": ["workflows/chipseq/*", "workflows/references/*"],
+    "rnaseq": ["workflows/rnaseq/*", "workflows/references/*"],
+    "colocalization": ["workflows/colocalization/*"],
+    "full": ["workflows/*"],
+}
+
 ap = argparse.ArgumentParser(usage=usage)
-ap.add_argument('--flavor', default='full', help='''Options are rnaseq,
-                chipseq, colocalization, full. Default is full.''')
-ap.add_argument('--dest', help='''Destination directory in which to copy files''')
-ap.add_argument('--build-env', action='store_true', help='''If specified,
-a conda environment with all dependencies will be installed into a directory
-                called "env" within the directory provided for --dest.  ''')
+ap.add_argument(
+    "--flavor",
+    default="full",
+    help="""Options are {0}. Default is full.""".format(list(flavors.keys())),
+)
+ap.add_argument("--dest", help="""Destination directory in which to copy files""")
+ap.add_argument(
+    "--build-env",
+    action="store_true",
+    help="""If specified, a conda environment with all dependencies will be
+    installed into a directory called "env" within the directory provided for
+    --dest.  """,
+)
+ap.add_argument("--verbose", "-v", action="store_true", help="""Verbose mode""")
 
 args = ap.parse_args()
 dest = args.dest
 flavor = args.flavor
 
 
-# Inclusions and exclusions:
-# Excluding files by name or by location is easy: --exclude=*~,
-# --exclude=/some/relative/location (relative to the source argument, e.g. this
-# excludes ~/LaTeX/some/relative/location).
-# If you only want to match a few files or locations, include them, include
-# every directory leading to them (for example with --include=*/), then exclude
-# the rest with --exclude='*'. This is because:
-# If you exclude a directory, this excludes everything below it. The excluded
-# files won't be considered at all.
-# If you include a directory, this doesn't automatically include its contents.
-# In recent versions, --include='directory/***' will do that.
-# For each file, the first matching rule applies (and anything never matched is
-# included).
-# Patterns:
-# If a pattern doesn't contain a /, it applies to the file name sans directory.
-# If a pattern ends with /, it applies to directories only.
-# If a pattern starts with /, it applies to the whole path from the directory
-# that was passed as an argument to rsync.
-# * any substring of a single directory component (i.e. never matches /); **
-# matches any path substring.
-flavors = {
-    'all': {
-        'include': [
-            'wrappers/wrappers',
-            'include',
-            'lib',
-            'requirements.txt',
-            '.gitignore',
-        ],
-        'exclude': [
-
-            '/.buildkite/*',
-            '/ci/*',
-            '/.circleci/*',
-            '/config/*',
-            '/deploy.py',
-            '/docs/***',
-            '/include/AnnotationHubCache',
-            '/lib/postprocess/__pycache__',
-            '/lib/__pycache__',
-            '*/.pytest_cache/*',
-            '/README.md',
-            '/test/*',
-            '/.travis.yml',
-            '/workflows/*/results',
-            '/workflows/*/data',
-            '/workflows/figures/*',
-            '/workflows/*/references_data',
-            '/workflows/*/references_dir',
-            '/workflows/*/reports',
-            '/workflows/rnaseq/downstream/final_clusters',
-            '/workflows/rnaseq/downstream/*html',
-            '/workflows/rnaseq/downstream/*log',
-            '/workflows/rnaseq/downstream/rnaseq_cache',
-            '/workflows/rnaseq/downstream/rnaseq_files',
-            '/workflows/rnaseq/downstream/*.tsv*',
-            '/workflows/*/run_test.sh',
-            '/workflows/*/Snakefile.test',
-            '/workflows/*/.snakemake',
-            '/wrappers/demo/*',
-            '/wrappers/test/*',
-            '/wrappers/test_toy.py',
-
-        ],
-    },
-    'chipseq': [
-        'workflows/chipseq/*',
-        'workflows/references/*',
-    ],
-    'rnaseq': [
-        'workflows/rnaseq/*',
-        'workflows/rnaseq/config/*',
-        'workflows/rnaseq/downstream/*',
-        'workflows/references/*',
-    ],
-    'colocalization': [
-        'workflows/colocalization/*',
-    ],
-
-    'full': [
-        'workflows/*',
-    ],
-}
-
-
-under_version_control = sorted(sp.check_output(
-    [ 'git', 'ls-tree', '-r', 'HEAD', '--name-only'],
-    universal_newlines=True).splitlines(False))
-
-
 def filter_out_excluded(filenames, patterns_to_exclude):
+    """
+    Only return the subset of `filenames` that do not match any
+    `patterns_to_exclude`.
+    """
     keep = []
     for filename in filenames:
-        if not any(fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_exclude):
+        if not any(
+            fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_exclude
+        ):
             keep.append(filename)
     return keep
 
-def filter_out_other_workflows(filenames, patterns_to_include, prefix='workflows'):
+
+def filter_out_other_workflows(filenames, patterns_to_include, prefilter="workflows/*"):
+    """
+    Return subset of `filenames` that:
+
+        - don't match `prefilter`
+        - match prefilter AND match any of `patterns_to_include`
+    """
     keep = []
     for filename in filenames:
-        if not filename.startswith(prefix):
+        # If it doesn't match prefilter, we don't want to do anything about it,
+        # so keep it and move on.
+        if not fnmatch.fnmatch(filename, prefilter):
             keep.append(filename)
             continue
+        # Otherwise, only keep it if it's in patterns_to_include.
         if any(fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_include):
             keep.append(filename)
     return keep
 
-keep = filter_out_excluded(under_version_control, flavors['all']['exclude'])
 
+# We start with anything under version control, and then progressively filter
+# out other stuff.
+under_version_control = sorted(
+    sp.check_output(
+        ["git", "ls-tree", "-r", "HEAD", "--name-only"], universal_newlines=True
+    ).splitlines(False)
+)
+keep = filter_out_excluded(under_version_control, always["exclude"])
 keep = filter_out_other_workflows(keep, flavors[flavor])
 
 exclude = tempfile.NamedTemporaryFile(delete=False).name
-exclude = '.exclude'
-with open(exclude, 'w') as fout:
-    fout.write('\n'.join(flavors['all']['exclude']))
+if args.verbose:
+    print("Exclude file: {}".format(exclude))
+with open(exclude, "w") as fout:
+    fout.write("\n".join(always["exclude"]))
 
 include = tempfile.NamedTemporaryFile(delete=False).name
-include = '.include'
-with open(include, 'w') as fout:
-    fout.write('\n\n')
-    fout.write('\n'.join(keep) + '\n')
+if args.verbose:
+    print("Include file: {}".format(include))
+with open(include, "w") as fout:
+    fout.write("\n\n")
+    fout.write("\n".join(keep) + "\n")
 
-sp.check_call([
-    'rsync',
-    '--relative',
-    '-v',
-    '-ar',
-    '--progress',
-    '--files-from={}'.format(include),
-    '--exclude-from={}'.format(exclude),
+rsync = [
+    "rsync",
+    "--relative",
+    "-ar",
+    "--progress",
+    "--files-from={}".format(include),
+    "--exclude-from={}".format(exclude),
     HERE,
-    dest])
+    dest,
+]
+if args.verbose:
+    rsync.append("-vv")
 
-commit, message = sp.check_output(
-    ['git', 'log', '--oneline', '-1'],
-    universal_newlines=True
-).strip().split(' ', 1)
-now = datetime.datetime.strftime(datetime.datetime.now(), '%Y%m%d%H%M')
-remotes = sp.check_output(
-    ['git', 'remote', '-v'],
-    universal_newlines=True
+sp.check_call(rsync)
+
+# This next section builds the .lcdb-wf-deployment.json data.
+#
+# First, the last commit:
+commit, message = (
+    sp.check_output(["git", "log", "--oneline", "-1"], universal_newlines=True)
+    .strip()
+    .split(" ", 1)
 )
+
+# When we're deploying:
+now = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M")
+
+# Where the remote was:
+remotes = sp.check_output(["git", "remote", "-v"], universal_newlines=True)
 remotes = [i.strip() for i in remotes.splitlines()]
-branch = sp.check_output([
-    'git', 'branch'], universal_newlines=True)
-branch = [i for i in branch.splitlines() if i.startswith('*')]
+
+# The branch we're deploying from:
+branch = sp.check_output(["git", "branch"], universal_newlines=True)
+branch = [i for i in branch.splitlines() if i.startswith("*")]
 assert len(branch) == 1
 branch = branch[0]
-branch = branch.split('* ')[1]
+branch = branch.split("* ")[1]
 
 d = {
-    'git': {
-        'commit': commit,
-        'message': message,
-        'remotes': remotes,
-        'branch': branch,
-    },
-    'timestamp': now}
-log = os.path.join(dest, '.lcdb-wf-deployment.json')
-with open(log, 'w') as fout:
-    fout.write(json.dumps(d) + '\n')
+    "git": {"commit": commit, "message": message, "remotes": remotes, "branch": branch},
+    "timestamp": now,
+}
+log = os.path.join(dest, ".lcdb-wf-deployment.json")
+with open(log, "w") as fout:
+    fout.write(json.dumps(d) + "\n")
 os.chmod(log, 0o440)
 
+
+# If specified, build an environment in `dest/env`, using the correct channels.
 if args.build_env:
     sp.check_call(
-        ['conda', 'create', '-y', '-p', './env', '--file', 'requirements.txt', '-c',
-         'conda-forge', '-c', 'bioconda', '-c', 'defaults'],
+        [
+            "conda",
+            "create",
+            "-y",
+            "-p",
+            "./env",
+            "--file",
+            "requirements.txt",
+            "-c",
+            "conda-forge",
+            "-c",
+            "bioconda",
+            "-c",
+            "defaults",
+        ],
         universal_newlines=True,
-        cwd=dest)
+        cwd=dest,
+    )

--- a/deploy.py
+++ b/deploy.py
@@ -36,6 +36,26 @@ dest = args.dest
 flavor = args.flavor
 
 
+# Inclusions and exclusions:
+# Excluding files by name or by location is easy: --exclude=*~,
+# --exclude=/some/relative/location (relative to the source argument, e.g. this
+# excludes ~/LaTeX/some/relative/location).
+# If you only want to match a few files or locations, include them, include
+# every directory leading to them (for example with --include=*/), then exclude
+# the rest with --exclude='*'. This is because:
+# If you exclude a directory, this excludes everything below it. The excluded
+# files won't be considered at all.
+# If you include a directory, this doesn't automatically include its contents.
+# In recent versions, --include='directory/***' will do that.
+# For each file, the first matching rule applies (and anything never matched is
+# included).
+# Patterns:
+# If a pattern doesn't contain a /, it applies to the file name sans directory.
+# If a pattern ends with /, it applies to directories only.
+# If a pattern starts with /, it applies to the whole path from the directory
+# that was passed as an argument to rsync.
+# * any substring of a single directory component (i.e. never matches /); **
+# matches any path substring.
 flavors = {
     'all': {
         'include': [
@@ -47,37 +67,37 @@ flavors = {
         ],
         'exclude': [
 
-            '.buildkite/*',
-            'ci/*',
-            '.circleci/*',
-            'config/*',
-            'deploy.py',
-            'docs/*',
-            'include/AnnotationHubCache',
-            'lib/postprocess/__pycache__',
-            'lib/__pycache__',
+            '/.buildkite/*',
+            '/ci/*',
+            '/.circleci/*',
+            '/config/*',
+            '/deploy.py',
+            '/docs/***',
+            '/include/AnnotationHubCache',
+            '/lib/postprocess/__pycache__',
+            '/lib/__pycache__',
             '*/.pytest_cache/*',
-            'README.md',
-            'test/*',
-            '.travis.yml',
-            'workflows/colocalization/results',
-            'workflows/*/data',
-            'workflows/figures/*',
-            'workflows/*/references_data',
-            'workflows/*/references_dir',
-            'workflows/*/reports',
-            'workflows/rnaseq/downstream/final_clusters',
-            'workflows/rnaseq/downstream/*html',
-            'workflows/rnaseq/downstream/*log',
-            'workflows/rnaseq/downstream/rnaseq_cache',
-            'workflows/rnaseq/downstream/rnaseq_files',
-            'workflows/rnaseq/downstream/*.tsv*',
-            'workflows/*/run_test.sh',
-            'workflows/*/Snakefile.test',
-            'workflows/*/.snakemake',
-            'wrappers/demo/*',
-            'wrappers/test/*',
-            'wrappers/test_toy.py',
+            '/README.md',
+            '/test/*',
+            '/.travis.yml',
+            '/workflows/*/results',
+            '/workflows/*/data',
+            '/workflows/figures/*',
+            '/workflows/*/references_data',
+            '/workflows/*/references_dir',
+            '/workflows/*/reports',
+            '/workflows/rnaseq/downstream/final_clusters',
+            '/workflows/rnaseq/downstream/*html',
+            '/workflows/rnaseq/downstream/*log',
+            '/workflows/rnaseq/downstream/rnaseq_cache',
+            '/workflows/rnaseq/downstream/rnaseq_files',
+            '/workflows/rnaseq/downstream/*.tsv*',
+            '/workflows/*/run_test.sh',
+            '/workflows/*/Snakefile.test',
+            '/workflows/*/.snakemake',
+            '/wrappers/demo/*',
+            '/wrappers/test/*',
+            '/wrappers/test_toy.py',
 
         ],
     },
@@ -87,6 +107,7 @@ flavors = {
     ],
     'rnaseq': [
         'workflows/rnaseq/*',
+        'workflows/rnaseq/config/*',
         'workflows/rnaseq/downstream/*',
         'workflows/references/*',
     ],


### PR DESCRIPTION
Previously, if a user ran the tests and then deployed right from that directory, some of the test output would be inadvertently copied over. This PR improves the deployment script to only ever pay attention to files under version control.

The tests have also been reconfigured so that they first use the deployment script and then run the tests over in the deployed directory. This test more closely matches real-world usage and ensures that everything is properly deployed.

It also adds an optional argument to build the conda env in the destination.