### PR TITLE
v1.5.1rc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,25 @@ variables:
     run:
       name: Download example data
       command: |
+        yum install -yy rsync
+        # container has a default python of 2.6, and we're using argparse, so
+        # we need to use the environment.
         source activate lcdb-wf-test
+
+        # Note that $DEPLOY is set in the "set-paths" step configured below.
+        python deploy.py --flavor full --dest $DEPLOY
+
+        # Separately copy over some test-specific files
+        cp workflows/chipseq/run_test.sh $DEPLOY/workflows/chipseq
+        cp workflows/rnaseq/run_test.sh $DEPLOY/workflows/rnaseq
+        cp workflows/colocalization/run_test.sh $DEPLOY/workflows/references
+        cp workflows/colocalization/run_test.sh $DEPLOY/workflows/colocalization
+        mkdir $DEPLOY/ci
+        cp ci/get-data.py $DEPLOY/ci
+        cp ci/preprocessor.py $DEPLOY/ci
+
+        # download example data
+        cd $DEPLOY
         python ci/get-data.py
 
   pytest-step: &pytest-step
@@ -63,7 +81,7 @@ variables:
       run:
         name: dry run
         command: |
-          cd workflows/rnaseq
+          cd $DEPLOY/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -n
 
@@ -71,7 +89,7 @@ variables:
       run:
         name: chipseq workflow
         command: |
-          cd workflows/chipseq
+          cd $DEPLOY/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python chipseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -80,11 +98,12 @@ variables:
       run:
         name: chipseq regression test workflow
         command: |
-          cd workflows/chipseq
+          ORIG=$(pwd)
+          cd $DEPLOY/workflows/chipseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r \
-            --configfile ../../test/test_configs/test_chipseq_regression.yaml \
-            --config sampletable=../../test/test_configs/chipseq_one_run.tsv \
+            --configfile $ORIG/test/test_configs/test_chipseq_regression.yaml \
+            --config sampletable=$ORIG/test/test_configs/chipseq_one_run.tsv \
             --config merged_bigwigs="{}" \
             --until bed_to_bigbed
 
@@ -92,7 +111,7 @@ variables:
       run:
         name: references workflow
         command: |
-          cd workflows/references
+          cd $DEPLOY/workflows/references
           source activate lcdb-wf-test
           ./run_test.sh  --use-conda -j2 -k -p -r
 
@@ -100,7 +119,7 @@ variables:
       run:
         name: rnaseq workflow
         command: |
-          cd workflows/rnaseq
+          cd $DEPLOY/workflows/rnaseq
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
           python rnaseq_trackhub.py config/config.yaml config/hub_config.yaml
@@ -109,48 +128,54 @@ variables:
       run:
         name: rnaseq star aligner
         command: |
+          ORIG=$(pwd)
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-star
           cd workflows/rnaseq-star
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -k -p -r \
             --forcerun star \
-            --configfile ../../test/test_configs/star_override.yaml \
-            --config sampletable=../../test/test_configs/two_samples.tsv \
+            --configfile $ORIG/test/test_configs/star_override.yaml \
+            --config sampletable=$ORIG/test/test_configs/two_samples.tsv \
             --until star
 
   rnaseq-sra-step: &rnaseq-sra-step
       run:
         name: rnaseq download from SRA
         command: |
+          ORIG=$(pwd)
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-sra-test
           cd workflows/rnaseq-sra-test
           source activate lcdb-wf-test
 
           ./run_test.sh --use-conda -k -p -r --until cutadapt \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_sra_sampletable.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_sra_sampletable.tsv
 
           ./run_test.sh --use-conda -k -p -r --until cutadapt \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_sra_sampletable_SE_only.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_sra_sampletable_SE_only.tsv
 
   rnaseq-pe-step: &rnaseq-pe-step
       run:
         name: rnaseq test PE
         command: |
+          ORIG=$(pwd)
+          cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-pe-test
           cd workflows/rnaseq-pe-test
           source activate lcdb-wf-test
 
           ./run_test.sh --use-conda -k -p -r --until multiqc \
-            --configfile ../../test/test_configs/override.yaml \
-            --config sampletable=../../test/test_configs/test_pe_sampletable.tsv
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_pe_sampletable.tsv
 
   colocalization-step: &colocalization-step
       run:
         name: colocalization workflow
         command: |
-          cd workflows/colocalization
+          cd $DEPLOY/workflows/colocalization
           source activate lcdb-wf-test
           ./run_test.sh --use-conda -j2 -k -p -r
 
@@ -160,6 +185,7 @@ variables:
         name: Set path
         command: |
           echo 'export PATH=$PATH:/root/project/miniconda/bin' >> $BASH_ENV
+          echo 'export DEPLOY=/tmp/lcdb-wf-test' >> $BASH_ENV
           source $BASH_ENV
 jobs:
 

--- a/deploy.py
+++ b/deploy.py
@@ -4,6 +4,8 @@ import argparse
 import subprocess as sp
 import datetime
 import json
+import fnmatch
+
 
 HERE = os.path.dirname(__file__)
 
@@ -21,109 +23,212 @@ used and the timestamp. This can be used to compare changes and stay
 up-to-date.
 """
 
+
+# Notes on include/exclude patterns for rsync:
+#
+# - Excluding a directory excludes everything below it
+# - Including a directory does not automatically include everything below it.
+# - Use "dir/***" to include everything
+# - Patterns with no / applies to basename
+# - Patterns ending with / implies directories only
+# - Patterns starting with / implies that the root is the source dir provided to rsync
+# - * is anything but /
+# - ** is any part of path, including /
+always = {
+    "include": [
+        "wrappers/wrappers",
+        "include",
+        "lib",
+        "requirements.txt",
+        ".gitignore",
+    ],
+    "exclude": [
+        "sra_sampletable.tsv",
+        "/.buildkite/*",
+        "/ci/*",
+        "/.circleci/*",
+        "/config/*",
+        "/deploy.py",
+        "/docs/***",
+        "/include/AnnotationHubCache",
+        "/lib/postprocess/__pycache__",
+        "/lib/__pycache__",
+        "*/.pytest_cache/*",
+        "/README.md",
+        "/test/***",
+        "/.travis.yml",
+        "/workflows/*/results",
+        "/workflows/*/data",
+        "/workflows/figures/*",
+        "/workflows/*/references_data",
+        "/workflows/*/references_dir",
+        "/workflows/*/reports",
+        "/workflows/rnaseq/downstream/final_clusters",
+        "/workflows/rnaseq/downstream/*html",
+        "/workflows/rnaseq/downstream/*log",
+        "/workflows/rnaseq/downstream/rnaseq_cache",
+        "/workflows/rnaseq/downstream/rnaseq_files",
+        "/workflows/rnaseq/downstream/*.tsv*",
+        "/workflows/*/run_test.sh",
+        "/workflows/*/Snakefile.test",
+        "/workflows/*/.snakemake",
+        "/wrappers/demo/*",
+        "/wrappers/test/*",
+        "/wrappers/test_toy.py",
+    ],
+}
+
+flavors = {
+    "chipseq": ["workflows/chipseq/*", "workflows/references/*"],
+    "rnaseq": ["workflows/rnaseq/*", "workflows/references/*"],
+    "colocalization": ["workflows/colocalization/*"],
+    "full": ["workflows/*"],
+}
+
 ap = argparse.ArgumentParser(usage=usage)
-ap.add_argument('--flavor', default='full', help='''Options are rnaseq, chipseq, colocalization, full. Default is full.''')
-ap.add_argument('--dest', help='''Destination directory in which to copy files''')
+ap.add_argument(
+    "--flavor",
+    default="full",
+    help="""Options are {0}. Default is full.""".format(list(flavors.keys())),
+)
+ap.add_argument("--dest", help="""Destination directory in which to copy files""")
+ap.add_argument(
+    "--build-env",
+    action="store_true",
+    help="""If specified, a conda environment with all dependencies will be
+    installed into a directory called "env" within the directory provided for
+    --dest.  """,
+)
+ap.add_argument("--verbose", "-v", action="store_true", help="""Verbose mode""")
+
 args = ap.parse_args()
 dest = args.dest
 flavor = args.flavor
 
-flavors = {
-    'all': {
-        'include': [
-            'wrappers/wrappers',
-            'include',
-            'lib',
-            'requirements.txt',
-        ],
-        'exclude': [
-            'wrappers/wrappers/demo',
-            'workflows/*/run_test.sh',
 
-            # The following files to exclude are those that are created from
-            # a test run.
-            'lib/__pycache__',
-            'lib/postprocess/__pycache__',
-            'include/AnnotationHubCache',
-            'workflows/*/Snakefile.test',
-            'workflows/*/references_data',
-            'workflows/*/.snakemake',
-            'workflows/*/data',
-            'workflows/rnaseq/downstream/rnaseq_cache',
-            'workflows/rnaseq/downstream/rnaseq_files',
-            'workflows/rnaseq/downstream/final_clusters',
-            'workflows/rnaseq/downstream/*.tsv*',
-            'workflows/rnaseq/downstream/*log',
-            'workflows/rnaseq/downstream/*html',
-            'workflows/colocalization/results',
-        ],
-    },
-    'chipseq': [
-        'workflows/chipseq',
-        'workflows/references',
-    ],
-    'rnaseq': [
-        'workflows/rnaseq',
-        'workflows/rnaseq/downstream/',
-        'workflows/references',
-    ],
-    'colocalization': [
-        'workflows/colocalization',
-    ],
+def filter_out_excluded(filenames, patterns_to_exclude):
+    """
+    Only return the subset of `filenames` that do not match any
+    `patterns_to_exclude`.
+    """
+    keep = []
+    for filename in filenames:
+        if not any(
+            fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_exclude
+        ):
+            keep.append(filename)
+    return keep
 
-    'full': [
-        'workflows',
-    ],
-}
 
-paths = set(flavors['all']['include'])
-paths = paths | set(flavors[flavor])
+def filter_out_other_workflows(filenames, patterns_to_include, prefilter="workflows/*"):
+    """
+    Return subset of `filenames` that:
+
+        - don't match `prefilter`
+        - match prefilter AND match any of `patterns_to_include`
+    """
+    keep = []
+    for filename in filenames:
+        # If it doesn't match prefilter, we don't want to do anything about it,
+        # so keep it and move on.
+        if not fnmatch.fnmatch(filename, prefilter):
+            keep.append(filename)
+            continue
+        # Otherwise, only keep it if it's in patterns_to_include.
+        if any(fnmatch.fnmatch(filename, pattern) for pattern in patterns_to_include):
+            keep.append(filename)
+    return keep
+
+
+# We start with anything under version control, and then progressively filter
+# out other stuff.
+under_version_control = sorted(
+    sp.check_output(
+        ["git", "ls-tree", "-r", "HEAD", "--name-only"], universal_newlines=True
+    ).splitlines(False)
+)
+keep = filter_out_excluded(under_version_control, always["exclude"])
+keep = filter_out_other_workflows(keep, flavors[flavor])
 
 exclude = tempfile.NamedTemporaryFile(delete=False).name
-with open(exclude, 'w') as fout:
-    fout.write('\n'.join(flavors['all']['exclude']))
+if args.verbose:
+    print("Exclude file: {}".format(exclude))
+with open(exclude, "w") as fout:
+    fout.write("\n".join(always["exclude"]))
 
 include = tempfile.NamedTemporaryFile(delete=False).name
-with open(include, 'w') as fout:
-    fout.write('\n'.join(paths) + '\n')
+if args.verbose:
+    print("Include file: {}".format(include))
+with open(include, "w") as fout:
+    fout.write("\n\n")
+    fout.write("\n".join(keep) + "\n")
 
-
-sp.check_call([
-    'rsync',
-    '--relative',
-    '-ar',
-    '--files-from={}'.format(include),
-    '--exclude-from={}'.format(exclude),
+rsync = [
+    "rsync",
+    "--relative",
+    "-ar",
+    "--progress",
+    "--files-from={}".format(include),
+    "--exclude-from={}".format(exclude),
     HERE,
-    dest])
+    dest,
+]
+if args.verbose:
+    rsync.append("-vv")
 
+sp.check_call(rsync)
 
-commit, message = sp.check_output(
-    ['git', 'log', '--oneline', '-1'],
-    universal_newlines=True
-).strip().split(' ', 1)
-now = datetime.datetime.strftime(datetime.datetime.now(), '%Y%m%d%H%M')
-remotes = sp.check_output(
-    ['git', 'remote', '-v'],
-    universal_newlines=True
+# This next section builds the .lcdb-wf-deployment.json data.
+#
+# First, the last commit:
+commit, message = (
+    sp.check_output(["git", "log", "--oneline", "-1"], universal_newlines=True)
+    .strip()
+    .split(" ", 1)
 )
+
+# When we're deploying:
+now = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M")
+
+# Where the remote was:
+remotes = sp.check_output(["git", "remote", "-v"], universal_newlines=True)
 remotes = [i.strip() for i in remotes.splitlines()]
-branch = sp.check_output([
-    'git', 'branch'], universal_newlines=True)
-branch = [i for i in branch.splitlines() if i.startswith('*')]
+
+# The branch we're deploying from:
+branch = sp.check_output(["git", "branch"], universal_newlines=True)
+branch = [i for i in branch.splitlines() if i.startswith("*")]
 assert len(branch) == 1
 branch = branch[0]
-branch = branch.split('* ')[1]
+branch = branch.split("* ")[1]
 
 d = {
-    'git': {
-        'commit': commit,
-        'message': message,
-        'remotes': remotes,
-        'branch': branch,
-    },
-    'timestamp': now}
-log = os.path.join(dest, '.lcdb-wf-deployment.json')
-with open(log, 'w') as fout:
-    fout.write(json.dumps(d) + '\n')
+    "git": {"commit": commit, "message": message, "remotes": remotes, "branch": branch},
+    "timestamp": now,
+}
+log = os.path.join(dest, ".lcdb-wf-deployment.json")
+with open(log, "w") as fout:
+    fout.write(json.dumps(d) + "\n")
 os.chmod(log, 0o440)
+
+
+# If specified, build an environment in `dest/env`, using the correct channels.
+if args.build_env:
+    sp.check_call(
+        [
+            "conda",
+            "create",
+            "-y",
+            "-p",
+            "./env",
+            "--file",
+            "requirements.txt",
+            "-c",
+            "conda-forge",
+            "-c",
+            "bioconda",
+            "-c",
+            "defaults",
+        ],
+        universal_newlines=True,
+        cwd=dest,
+    )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,11 +2,47 @@ Changelog
 =========
 
 v1.5.1rc
-~~~~~~~~
+--------
+
+Bug fixes
+~~~~~~~~~
+
+- DESeqDataSetFromCombinedFeatureCounts (added in v1.5) was incorrectly
+  assigning labels to samples when the order of the sampletable did not match
+  the order of the samples in the featureCounts table columns. This has been
+  fixed.
+
+General
+~~~~~~~
 
 - `deploy.py` deployment script now only pays attention to files checked in to
   version control and optionally can create a conda environment in the target
   directory.
+
+- tests now work out of a newly-deployed instance to better reflect real-world
+  usage
+
+- reorder cutadapt commands to avoid a MultQC parsing bug in the cutadapt module (see https://github.com/ewels/MultiQC/issues/949)
+
+RNA-seq
+~~~~~~~
+
+- modifications to MultiQC config to get back featureCounts output
+
+- `plotMA.label` function (in ``helpers.Rmd``) now defaults to FDR < 0.1
+  (instead of 0.01), and additionally supports labeling using different columns
+  of the results object (e.g., "symbol").
+
+``rnaseq.Rmd``
+~~~~~~~~~~~~~~
+- remove some now-redundant featureCounts code
+- add a comment showing where to collapse replicates
+- convert colData's first column to rownames
+- implement lower limit for DEGpatterns clustering (default is 0, but can
+  easily set to higher if you're getting issues)
+
+
+
 
 v1.5 (Sept 2019)
 ----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v1.5.1rc
+~~~~~~~~
+
+- `deploy.py` deployment script now only pays attention to files checked in to
+  version control and optionally can create a conda environment in the target
+  directory.
+
 v1.5 (Sept 2019)
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,26 +22,28 @@ General
 - tests now work out of a newly-deployed instance to better reflect real-world
   usage
 
-- reorder cutadapt commands to avoid a MultQC parsing bug in the cutadapt module (see https://github.com/ewels/MultiQC/issues/949)
+
+ChIP-seq and RNA-seq
+~~~~~~~~~~~~~~~~~~~~
+- reorder cutadapt commands to avoid a MultQC parsing bug in the cutadapt
+  module (see https://github.com/ewels/MultiQC/issues/949)
 
 RNA-seq
 ~~~~~~~
+The majority of these changes affect ``rnaseq.Rmd``:
 
 - modifications to MultiQC config to get back featureCounts output
-
 - `plotMA.label` function (in ``helpers.Rmd``) now defaults to FDR < 0.1
   (instead of 0.01), and additionally supports labeling using different columns
   of the results object (e.g., "symbol").
-
-``rnaseq.Rmd``
-~~~~~~~~~~~~~~
 - remove some now-redundant featureCounts code
 - add a comment showing where to collapse replicates
 - convert colData's first column to rownames
 - implement lower limit for DEGpatterns clustering (default is 0, but can
   easily set to higher if you're getting issues)
-
-
+- expose arbitrary additional function arguments to ``top.plots``. This allows
+  different `intgroup` arguments to be passed to the `my.counts` function,
+  enabling different ways of plotting the gene dotplots.
 
 
 v1.5 (Sept 2019)

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -187,24 +187,24 @@ rule cutadapt:
         if paired:
             shell(
                 "cutadapt "
-                "{input.fastq[0]} "
-                "{input.fastq[1]} "
                 "-o {output[0]} "
                 "-p {output[1]} "
                 "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA "
                 "-A AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT "
                 '-q 20 '
                 '--minimum-length 25 '
+                "{input.fastq[0]} "
+                "{input.fastq[1]} "
                 "&> {log}"
             )
         else:
             shell(
                 "cutadapt "
-                "{input.fastq[0]} "
                 "-o {output[0]} "
                 "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA "
                 '-q 20 '
                 '--minimum-length 25 '
+                "{input.fastq[0]} "
                 "&> {log}"
             )
 

--- a/workflows/references/Snakefile
+++ b/workflows/references/Snakefile
@@ -184,7 +184,7 @@ rule conversion_bed12:
     output:
         protected('{references_dir}/{organism}/{tag}/gtf/{organism}_{tag}.bed12')
     shell:
-        'gtfToGenePred {input} {output}.tmp '
+        'gtfToGenePred -ignoreGroupsWithoutExons {input} {output}.tmp '
         '&& genePredToBed {output}.tmp {output}'
 
 rule conversion_gffutils:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -178,8 +178,6 @@ rule cutadapt:
         if c.is_paired:
             shell(
                 "cutadapt "
-                "{input.fastq[0]} "
-                "{input.fastq[1]} "
                 "-o {output[0]} "
                 "-p {output[1]} "
                 "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA "
@@ -187,16 +185,18 @@ rule cutadapt:
                 '-q 20 '
                 '-j {threads} '
                 '--minimum-length 25 '
+                "{input.fastq[0]} "
+                "{input.fastq[1]} "
                 "&> {log}"
             )
         else:
             shell(
                 "cutadapt "
-                "{input.fastq[0]} "
                 "-o {output[0]} "
                 "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA "
                 '-q 20 '
                 '--minimum-length 25 '
+                "{input.fastq[0]} "
                 "&> {log}"
             )
 

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -70,7 +70,7 @@ module_order:
     - featureCounts:
         name: 'featureCounts'
         path_filters:
-            - '*.cutadapt.bam.featurecounts.txt.summary'
+            - 'featurecounts.txt.summary'
 
 # This organizes the FastQC general sample table columns so that the different
 # stages are right next to each other, making it easier to compare the effects
@@ -90,12 +90,3 @@ table_columns_placement:
     total_sequences: 22
     percent_duplicates: 32
     percent_gc: 42
-  featureCounts (unstranded):
-    percent_assigned: 100
-    Assigned: 106
-  featureCounts (sense):
-    percent_assigned: 101
-    Assigned: 107
-  featureCounts (antisense):
-    percent_assigned: 102
-    Assigned: 108

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -68,18 +68,9 @@ module_order:
     - rseqc
     - salmon
     - featureCounts:
-        name: 'featureCounts (unstranded)'
+        name: 'featureCounts'
         path_filters:
-            - '*.cutadapt.bam.featurecounts.s0.txt.summary'
-    - featureCounts:
-        name: 'featureCounts (sense)'
-        path_filters:
-            - '*.cutadapt.bam.featurecounts.s1.txt.summary'
-    - featureCounts:
-        name: 'featureCounts (antisense)'
-        path_filters:
-            - '*.cutadapt.bam.featurecounts.s2.txt.summary'
-
+            - '*.cutadapt.bam.featurecounts.txt.summary'
 
 # This organizes the FastQC general sample table columns so that the different
 # stages are right next to each other, making it easier to compare the effects

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -235,9 +235,14 @@ DESeqDataSetFromCombinedFeatureCounts <- function(filename, sampletable, design,
     #
     #   sample1 sample2 sample3 sample4
     #         2       1       4       3
-    colnames(m) <- names(hits)[hits]
+    #
+    # Sorting this list will give us the order of names that were in the counts
+    # table. So we can reorder the sampletable accordingly.
+    colnames(m) <- names(sort(hits))
+    sampletable.rearranged <- sampletable[colnames(m),]
 
-    object <- DESeqDataSetFromMatrix(countData=m, colData=sampletable, design=design, ...)
+
+    object <- DESeqDataSetFromMatrix(countData=m, colData=sampletable.rearranged, design=design, ...)
     return(object)
 }
 

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -393,13 +393,14 @@ padj.order <- function(res, reverse=FALSE){
 #'
 #' @param sorted DESeq2 results object
 #' @param n Number of top genes to plot
-#' @param func Plotting function to call on each gene
+#' @param func Plotting function to call on each gene. Signature is func(gene,
+#'             dds, label=label, ...)
 #' @param dds DESeq2 object
 #' @param label Vector of column names in `res` from which to add a label to
-#'   the gene (e.g., c('symbol', 'alias'))
-#'
+#'        the gene (e.g., c('symbol', 'alias'))
+#' @param ... Additional arguments that are passed to `func`
 #' @return Side effect is to create plot
-top.plots <- function(res, n, func, dds, add_cols=NULL){
+top.plots <- function(res, n, func, dds, add_cols=NULL, ...){
     ps <- list()
     for (i in seq(n)){
         gene <- rownames(res)[i]
@@ -409,7 +410,7 @@ top.plots <- function(res, n, func, dds, add_cols=NULL){
         if (length(label) == 0){
           label <- NULL
         }
-        ps[[gene]] <- func(gene, dds, label=label)
+        ps[[gene]] <- func(gene, dds, label=label, ...)
     }
     grid.arrange(grobs=ps)
 }

--- a/workflows/rnaseq/downstream/helpers.Rmd
+++ b/workflows/rnaseq/downstream/helpers.Rmd
@@ -74,15 +74,24 @@ plotPCA.ly <- function(rld, intgroup){
 #' @param fc.lim User-defined limits for y-axis (log2FC). If NULL, this is defined as
 #'        the (floor, ceiling) of range(res$log2FoldChange)
 #' @param genes.to.label Genes to label on the MA plot. NULL, by default
+#' @param col Column of `res` in which to look for `genes.to.label`. If NULL,
+#'        rownames are used.
 #'
 #' @return Handle to ggplot
 plotMA.label <- function(res,
-                         fdr.thres=0.01,
+                         fdr.thres=0.1,
                          fc.thres=0,
                          fc.lim=NULL,
-                         genes.to.label=NULL){
+                         genes.to.label=NULL,
+                         col=NULL
+                         ){
   # TODO: Add ggrastr option for points
-
+  genes.to.label <- as.character(genes.to.label)
+  nna <- sum(is.na(genes.to.label))
+  if (nna > 0){
+      warning(paste("Removing", nna, "NAs from gene list"))
+      genes.to.label <- genes.to.label[!is.na(genes.to.label)]
+  }
   # convert res to data frame
   res <- data.frame(res)
 
@@ -128,8 +137,14 @@ plotMA.label <- function(res,
 
   if(!is.null(genes.to.label)){
     # get data frame of genes to be labeled
-    label.list <- res[rownames(res) %in% genes.to.label,]
-    label.list <- data.frame(genes=rownames(label.list), label.list)
+    if (!is.null(col)){
+        res$gene.labels <- res[,col]
+    } else {
+        res$gene.labels <- rownames(res)
+    }
+
+    label.list <- res[res$gene.labels %in% genes.to.label,]
+    #label.list <- data.frame(genes=rownames(label.list), label.list)
 
     # label genes outside limits
     up.max.idx <- rownames(label.list) %in% rownames(up.max)
@@ -145,7 +160,7 @@ plotMA.label <- function(res,
 
     # add labels
     p <- p + geom_point(data=label.list, col="black", pch=1, size=3)
-    p <- p + geom_label_repel(data=label.list, aes(label=label.list$genes, fontface="italic"))
+    p <- p + geom_label_repel(data=label.list, aes(label=label.list$gene.labels, fontface="italic"))
   }
   return(p)
 

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -187,6 +187,10 @@ dds <- DESeqDataSetFromCombinedFeatureCounts(
     #   later for the actual contrasts of interest.
     design=~group)
 
+# NOTE: collapse technical replicates ---------------------------------------- 
+#   If collapsing technical replicates, do so here
+# dds <-collapseReplicates(dds, dds$biorep)
+
 if (strip.dotted.version){
     rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
 }
@@ -295,6 +299,10 @@ dds <- DESeqDataSetFromCombinedFeatureCounts(
 if (strip.dotted.version){
     rownames(dds) <- sapply(strsplit(rownames(dds), '.', fixed=TRUE), function (x) x[1])
 }
+
+# NOTE: collapse technical replicates ----------------------------------------
+#  If collapsing technical replicates, do so (again) here
+# dds <-collapseReplicates(dds, dds$biorep)
 
 dds <- DESeq(dds,
     # NOTE: betaPrior----------------------------------------------------------

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -34,7 +34,7 @@ knitr::opts_chunk$set(warning=FALSE, message=FALSE)
 
 # Changelog
 
-**Initial results** 
+**Initial results**
 
 Last run: `r date()`
 
@@ -187,7 +187,7 @@ dds <- DESeqDataSetFromCombinedFeatureCounts(
     #   later for the actual contrasts of interest.
     design=~group)
 
-# NOTE: collapse technical replicates ---------------------------------------- 
+# NOTE: collapse technical replicates ----------------------------------------
 #   If collapsing technical replicates, do so here
 # dds <-collapseReplicates(dds, dds$biorep)
 

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -560,6 +560,11 @@ The default general flow is as follows:
 #   this many
 lim <- 2000
 
+
+# NOTE: Min number of genes to include----------------------------------------
+#   If fewer than this many genes, skip the clustering
+lower.lim <- 0
+
 # NOTE:  Correlation coefficient above which to merge clusters-----------------
 cutoff <- 0.5
 
@@ -596,6 +601,9 @@ ll <- lapply(res.list, function (x) get.sig(x[['res']], 'changed'))
 ll <- ll[lapply(ll, length) > 0]
 
 for (name in names(ll)){
+    # Print a nice Markdown header
+    mdcat('## ', res.list[[name]][['label']])
+
     genes <- ll[[name]]
 
     # Plotting a large number of genes will take a lot of time to perform the
@@ -603,6 +611,11 @@ for (name in names(ll)){
     # sample.
     if (length(genes) > lim){
         genes <- sample(genes, lim)
+    }
+
+    if (length(genes) < lower.lim){
+        mdcat('**Too few genes (', length(genes), ') to cluster**')
+        next
     }
 
     # Extract the normalized counts for these genes

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -136,6 +136,8 @@ for (col in factor.columns){
 #   For the test data, "control" is the base level for the "group" factor, but
 #   you will need to edit as appropriate for your experimenal design.
 colData$group <- relevel(colData$group, ref='control')
+
+rownames(colData) <- colData[,1]
 ```
 
 ## Experiment overview

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -113,26 +113,8 @@ strip.dotted.version <- TRUE
 #   columns here.
 exclude.for.printing <- c('featurecounts.path', 'salmon.path', 'orig_filename', 'orig_filename_R2')
 
-colData <- read.table(sample.table.filename, sep='\t', header=TRUE, stringsAsFactors=FALSE))
+colData <- read.table(sample.table.filename, sep='\t', header=TRUE, stringsAsFactors=FALSE)
 
-# NOTE: Specify which featureCounts strandedness to use.-----------------------
-#   All three are created by default in the workflow, but here is where you
-#   specify which one to use for differential expression. This will be used to
-#   construct the paths to the correct featureCounts output files
-featurecounts.strandedness <- 's0'  # unstranded
-# featurecounts.strandedness <- 's1' # plus-strand reads correspond to sense-strand transcription (e.g., Ovation kits)
-# featurecounts.strandedness <- 's2' # minus-strand reads correspond to sense-strand transcription (e.g., TruSeq kits)
-
-# NOTE: Paths to featureCounts output---------------------------------------
-#   This is configured in the patterns and targets from the workflow; if you've
-#   changed anything there you will need to change it here as well.
-colData$featurecounts.path <- sapply(
-    colData$samplename,
-    function (x) file.path(
-        '..', 'data', 'rnaseq_samples', x,
-        paste0(x, '.cutadapt.bam.featurecounts.', featurecounts.strandedness, '.txt')
-        )
-    )
 
 # NOTE: Paths to Salmon output----------------------------------------------
 #    This is configured in the patterns and targets from the workflow; if

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -113,7 +113,7 @@ strip.dotted.version <- TRUE
 #   columns here.
 exclude.for.printing <- c('featurecounts.path', 'salmon.path', 'orig_filename', 'orig_filename_R2')
 
-colData <- read.table(sample.table.filename, sep='\t', header=TRUE)
+colData <- read.table(sample.table.filename, sep='\t', header=TRUE, stringsAsFactors=FALSE))
 
 # NOTE: Specify which featureCounts strandedness to use.-----------------------
 #   All three are created by default in the workflow, but here is where you

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -454,13 +454,16 @@ for (name in names(res.list)){
   mdcat('### Normalized counts of top 3 downregulated genes')
   top.plots(padj.order(res.i, reverse=TRUE), 3, my.counts, dds.i, add_cols)
 
-  # NOTE: By default we plot the top 10 upregulated or downregulated genes, with the lowest padj
-  # To change this behavior edit the following lines
+  # NOTE: gene labels --------------------------------------------------------
+  #   By default we plot the symbols of the top 10 upregulated or downregulated
+  #   genes, with the lowest padj. To change this behavior edit the following
+  #   lines
   res.i <- res.i[order(res.i$padj),]
-  genes.to.label <- rownames(res.i)[1:10]
+
+  genes.to.label <- res.i[1:10, 'symbol']
 
   mdcat('### M-A plot')
-  print(plotMA.label(res.i, genes.to.label=genes.to.label))
+  print(plotMA.label(res.i, genes.to.label=genes.to.label, col='symbol'))
 
   mdcat('### P-value distribution')
   pval.hist(res.i)

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -622,8 +622,6 @@ for (name in names(ll)){
     idx <- rownames(rld) %in% genes
     ma <- assay(rld)[idx,]
 
-    # Print a nice Markdown header
-    mdcat('## ', res.list[[name]][['label']])
     colData.i <- colData(res.list[[name]][['dds']])
     colData.i <- colData.i[,!(colnames(colData.i) %in% exclude.for.printing)]
 


### PR DESCRIPTION
Release candidate branch for v1.5.1.

- BUG: v1.5 was not correctly importing featurecounts tables when sampletable and featurecounts tables had different order
- #213: improved deploy script
- tests work from a newly-deployed instance
- reorder cutadapt commands to avoid a MultiQC parsing bug
- featurecounts output now back in multiqc report
- plotMA.label now defaults to FDR < 0.1, and additionally supports labeling with user-specified columns
- remove some deprecated featurecounts code
- implement lower limit for DEGpatterns clustering (to help with cases where there's only a single cluster)
- expose arbitrary function args to `top.plots` that are passed to the provided `func`
