### PR TITLE
.gitignore, rnaseq.rmd dependencies, rseqc read_distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ workflows/rnaseq/downstream/group.tsv
 workflows/rnaseq/downstream/rnaseq.html
 workflows/rnaseq/downstream/rnaseq_cache
 workflows/rnaseq/downstream/rnaseq_files
-workflows/rnaseq/downstream/cluster_profiler
+workflows/rnaseq/downstream/clusterprofiler
 workflows/rnaseq/downstream/upset_plots
 workflows/rnaseq/downstream/final_clusters
 workflows/rnaseq/downstream/rnaseq.log
@@ -19,8 +19,7 @@ slurm*out
 workflows/figures/figures
 docs/_build
 \.cache/v/cache/
-/workflows/chipseq/Snakefile.test
-/workflows/rnaseq/Snakefile.test
+*Snakefile.test
 workflows/rnaseq/staging/
 env
 include/AnnotationHubCache

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ workflows/rnaseq/downstream/group.tsv
 workflows/rnaseq/downstream/rnaseq.html
 workflows/rnaseq/downstream/rnaseq_cache
 workflows/rnaseq/downstream/rnaseq_files
+workflows/rnaseq/downstream/cluster_profiler
+workflows/rnaseq/downstream/upset_plots
+workflows/rnaseq/downstream/final_clusters
+workflows/rnaseq/downstream/rnaseq.log
 workflows/rnaseq/downstream/*tsv
 workflows/chipseq/data
 workflows/rnaseq/data
@@ -19,3 +23,5 @@ docs/_build
 /workflows/rnaseq/Snakefile.test
 workflows/rnaseq/staging/
 env
+include/AnnotationHubCache
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ pytest-runner >=2.11
 pytest-xdist
 pyyaml >=3.12
 r-base ==3.5.1
+r-batchjobs
 r-bindrcpp
 r-codetools
 r-dt

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -760,6 +760,20 @@ rule rseqc_infer_experiment:
     shell:
         'infer_experiment.py -r {input.bed12} -i {input.bam} > {output} &> {log}'
 
+rule rseqc_read_distribution:
+    """
+    read distribution plots
+    """
+    input:
+        bam=c.patterns['bam'],
+        bed12=c.refdict[c.organism][config['gtf']['tag']]['bed12'],
+    output:
+        txt=c.patterns['rseqc']['read_distribution']
+    log:
+        c.patterns['rseqc']['infer_experiment'] + '.log'
+        
+    shell:
+        'read_distribution.py -i {input.bam} -r {input.bed12} > {output} &> {log}'
 
 rule bigwig_neg:
     """

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -770,7 +770,7 @@ rule rseqc_read_distribution:
     output:
         txt=c.patterns['rseqc']['read_distribution']
     log:
-        c.patterns['rseqc']['infer_experiment'] + '.log'
+        c.patterns['rseqc']['read_distribution'] + '.log'
         
     shell:
         'read_distribution.py -i {input.bam} -r {input.bed12} > {output} &> {log}'

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -39,6 +39,7 @@ salmon: 'data/rnaseq_samples/{sample}/{sample}.salmon/quant.sf'
 rseqc:
    bam_stat: 'data/rnaseq_samples/{sample}/rseqc/{sample}_bam_stat.txt'
    infer_experiment: 'data/rnaseq_samples/{sample}/rseqc/{sample}_infer_experiment.txt'
+   read_distribution: 'data/rnaseq_samples/{sample}/rseqc/{sample}_read_distribution.txt'
 bigwig:
    pos: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.pos.bigwig'
    neg: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam.neg.bigwig'

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -29,7 +29,11 @@ output:
 ```
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(warning=FALSE, message=FALSE, cache.extra_file_dep_1 = file.info('../config/sampletable.tsv')$mtime, cache.extra_file_dep_2 = file.info('../data/rnaseq_aggregation/featurecounts.txt')$mtime)
+knitr::opts_chunk$set(
+    warning=FALSE,
+    message=FALSE,
+    cache.extra_file_dep_1=file.info('../config/sampletable.tsv')$mtime,
+    cache.extra_file_dep_2=file.info('../data/rnaseq_aggregation/featurecounts.txt')$mtime)
 ```
 
 # Changelog
@@ -214,7 +218,7 @@ we expect to see replicates clustering together and separation of treatments.
 
 ## Clustered heatmap
 
-```{r, cache=TRUE, dependson='dds_initial'}
+```{r}
 # NOTE: Which columns to use for grouping the heatmap?-------------------------
 #    Add as many columns as you want for the last argument. The test data uses
 #    just the "group" column to create colored boxes corresponding to values of
@@ -231,7 +235,7 @@ dimensions along which the samples vary the most. The amount of variance
 explained by each principal component is indicated in the axes label.
 
 
-```{r, results='asis', cache=TRUE, dependson='dds_initial'}
+```{r, results='asis'}
 # NOTE: Which columns to use for grouping the heatmap?-------------------------
 #    See similiar note above for which columns to group by. Here, each PCA plot
 #    will be in a separate tab.

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -29,7 +29,10 @@ output:
 ```
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(warning=FALSE, message=FALSE)
+knitr::opts_chunk$set(warning=FALSE, message=FALSE, autodep=TRUE, cache.extra_file_dep_1 = file.info('../config/sampletable.tsv')$mtime, cache.extra_file_dep_2 = file.info('../data/rnaseq_aggregation/featurecounts.txt')$mtime)
+
+#automatically identify cache dependencies
+knitr::dep_auto()
 ```
 
 # Changelog
@@ -54,6 +57,8 @@ library(UpSetR)
 library(ReactomePA)
 library(cowplot)
 library(plotly)
+library(tibble)
+library(dplyr)
 ```
 
 
@@ -602,7 +607,7 @@ low.minc <- 1
   more, they are merged together
 - Clusters with fewer than `r minc` genes are not shown.
 
-```{r, fig.width=12, results='asis', cache=TRUE}
+```{r final_clusters, fig.width=12, results='asis', cache=TRUE}
 # NOTE: which genes to cluster?------------------------------------------------
 #    By default, we get all the changed genes, but you may want only the up or
 #    down genes.
@@ -770,7 +775,6 @@ kegg.organism <- 'dme'
 RUN.REACTOME <- FALSE
 reactome.organism <- 'fly'
 
-
 # list to hold all enrichment results
 # will have structure:
 #
@@ -869,7 +873,7 @@ Below we show the results separately for each comparison. Links to files
 containing analysis results are shown above each set of plots, with parsed
 files showing genes on separate lines.
 
-```{r plot_go, fig.width=15, fig.height=10, results='asis'}
+```{r plot_go, fig.width=15, fig.height=10, results='asis', cache=TRUE}
 # go labels for file names
 go.label <- list(
     BP='GO Biological Process',

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -29,10 +29,7 @@ output:
 ```
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(warning=FALSE, message=FALSE, autodep=TRUE)
-
-#automatically identify cache dependencies
-knitr::dep_auto()
+knitr::opts_chunk$set(warning=FALSE, message=FALSE)
 ```
 
 # Changelog
@@ -262,7 +259,7 @@ ggplotly(p[[i]])
 ```
 
 
-## Size factors
+## Size factors {.tabset}
 Size factors: ideally, all libraries were sequenced to identical depth, in
 which case all size factors would be 1.0. In practice, this is almost never the
 case. These size factor estimates are DESeq2's way of showing how sequencing
@@ -273,8 +270,16 @@ careful about interpreting results.
 ```{r}
 dds <- estimateSizeFactors(dds)
 sf <- sizeFactors(dds)
-sf <- sf[order(sf)]
-knitr::kable(sf)
+sf <- sf[order(sf)] %>%
+        enframe(value = 'Size Factor')
+trc <- colSums(counts(dds)) %>%
+        enframe(value = 'Total Read Count')
+trc_vs_sf <- full_join(sf, trc, by = 'name')
+group_names = tibble(name=dds$samplename, group=dds$group)
+trc_vs_sf <- full_join(trc_vs_sf, group_names, by = 'name')
+p <- ggplot(data=trc_vs_sf, aes_string(x="`Total Read Count`", y="`Size Factor`", color='group', label='name')) +
+    geom_point(size=3)
+ggplotly(p)
 ```
 
 ```{r}

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -29,10 +29,7 @@ output:
 ```
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(warning=FALSE, message=FALSE, autodep=TRUE, cache.extra_file_dep_1 = file.info('../config/sampletable.tsv')$mtime, cache.extra_file_dep_2 = file.info('../data/rnaseq_aggregation/featurecounts.txt')$mtime)
-
-#automatically identify cache dependencies
-knitr::dep_auto()
+knitr::opts_chunk$set(warning=FALSE, message=FALSE, cache.extra_file_dep_1 = file.info('../config/sampletable.tsv')$mtime, cache.extra_file_dep_2 = file.info('../data/rnaseq_aggregation/featurecounts.txt')$mtime)
 ```
 
 # Changelog
@@ -217,7 +214,7 @@ we expect to see replicates clustering together and separation of treatments.
 
 ## Clustered heatmap
 
-```{r}
+```{r, cache=TRUE, dependson='dds_initial'}
 # NOTE: Which columns to use for grouping the heatmap?-------------------------
 #    Add as many columns as you want for the last argument. The test data uses
 #    just the "group" column to create colored boxes corresponding to values of
@@ -234,7 +231,7 @@ dimensions along which the samples vary the most. The amount of variance
 explained by each principal component is indicated in the axes label.
 
 
-```{r, results='asis'}
+```{r, results='asis', cache=TRUE, dependson='dds_initial'}
 # NOTE: Which columns to use for grouping the heatmap?-------------------------
 #    See similiar note above for which columns to group by. Here, each PCA plot
 #    will be in a separate tab.
@@ -280,7 +277,7 @@ sf <- sf[order(sf)] %>%
 trc <- colSums(counts(dds)) %>%
         enframe(value = 'Total Read Count')
 trc_vs_sf <- full_join(sf, trc, by = 'name')
-group_names = tibble(name=dds$samplename, group=dds$group)
+group_names <- tibble(name=dds$samplename, group=dds$group)
 trc_vs_sf <- full_join(trc_vs_sf, group_names, by = 'name')
 p <- ggplot(data=trc_vs_sf, aes_string(x="`Total Read Count`", y="`Size Factor`", color='group', label='name')) +
     geom_point(size=3)
@@ -483,7 +480,7 @@ for (name in names(res.list)){
 }
 ```
 
-```{r selections}
+```{r selections, cache=TRUE, dependson='attach'}
 sel.list <- list()
 for (name in names(res.list)){
   res <- res.list[[name]][['res']]
@@ -507,7 +504,7 @@ for (name in names(res.list)){
 sel.names <- names(sel.list[[name]])
 ```
 
-```{r upsetplots, results='asis'}
+```{r upsetplots, results='asis', cache=TRUE, dependson='selections'}
 # UpSet plots only make sense for more than one set of genes. The Markdown
 # explanatory text and the plots themselves are only created if res.list has
 # multiple items in it.
@@ -579,7 +576,7 @@ lim <- 2000
 
 # NOTE: Min number of genes to include----------------------------------------
 #   If fewer than this many genes, skip the clustering
-lower.lim <- 0
+lower.lim <- 5
 
 # NOTE:  Correlation coefficient above which to merge clusters-----------------
 cutoff <- 0.5
@@ -607,7 +604,7 @@ low.minc <- 1
   more, they are merged together
 - Clusters with fewer than `r minc` genes are not shown.
 
-```{r final_clusters, fig.width=12, results='asis', cache=TRUE}
+```{r final_clusters, fig.width=12, results='asis', cache=TRUE, dependson='selections'}
 # NOTE: which genes to cluster?------------------------------------------------
 #    By default, we get all the changed genes, but you may want only the up or
 #    down genes.
@@ -629,7 +626,7 @@ for (name in names(ll)){
         genes <- sample(genes, lim)
     }
 
-    if (length(genes) < lower.lim){
+    if (length(genes) <= lower.lim){
         mdcat('**Too few genes (', length(genes), ') to cluster**')
         next
     }
@@ -760,7 +757,7 @@ deg.list <- nested.lapply(sel.list, rownames)
 genes.df <- nested.lapply(deg.list, bitr, fromType=from.type, toType=types, OrgDb=orgdb)
 ```
 
-```{r enrich_all, results='hide', cache=TRUE}
+```{r enrich_all, results='hide', cache=TRUE, dependson='final_clusters'}
 
 # run enrichment for all gene lists over a loop
 
@@ -873,7 +870,7 @@ Below we show the results separately for each comparison. Links to files
 containing analysis results are shown above each set of plots, with parsed
 files showing genes on separate lines.
 
-```{r plot_go, fig.width=15, fig.height=10, results='asis', cache=TRUE}
+```{r plot_go, fig.width=15, fig.height=10, results='asis', cache=TRUE, dependson='enrich_all'}
 # go labels for file names
 go.label <- list(
     BP='GO Biological Process',

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -29,7 +29,10 @@ output:
 ```
 
 ```{r global_options, include=FALSE}
-knitr::opts_chunk$set(warning=FALSE, message=FALSE)
+knitr::opts_chunk$set(warning=FALSE, message=FALSE, autodep=TRUE)
+
+#automatically identify cache dependencies
+knitr::dep_auto()
 ```
 
 # Changelog


### PR DESCRIPTION
Issues #223 and #232 
The dependency thing should be tested to see if the functional enrichment cache is too easily invalidated. The parent objects it relies on ma y be be changed in previous chunks but the attributes themselves may not be. The documentation is unclear at what level that operates. IT appears it may be conservative at the level of the object. But it is not clear.