### PR TITLE
Add strand check rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,18 +429,10 @@ workflows:
          requires:
            - initial-setup
            - pytest
-         filters:
-           branches:
-             ignore:
-               - master
       - chipseq-regression:
          requires:
            - initial-setup
            - pytest
-         filters:
-           branches:
-             ignore:
-               - master
       - rnaseq-dryrun:
          requires:
            - initial-setup
@@ -450,53 +442,29 @@ workflows:
             - initial-setup
             - pytest
             - rnaseq-dryrun
-          filters:
-            branches:
-              ignore:
-                - master
       - rnaseq-star:
           requires:
             - initial-setup
             - pytest
             - rnaseq-dryrun
-          filters:
-            branches:
-              ignore:
-                - master
       - rnaseq-misc:
           requires:
             - initial-setup
             - pytest
             - rnaseq-dryrun
-          filters:
-            branches:
-              ignore:
-                - master
       - rnaseq-pe:
           requires:
             - initial-setup
             - pytest
             - rnaseq-dryrun
-          filters:
-            branches:
-              ignore:
-                - master
       - references:
           requires:
             - initial-setup
             - pytest
-          filters:
-            branches:
-              ignore:
-                - master
       - colocalization:
           requires:
             - initial-setup
             - pytest
-          filters:
-            branches:
-              ignore:
-                - master
       - build-docs:
           requires:
             - initial-setup
@@ -510,7 +478,3 @@ workflows:
             - chipseq
             - references
             - colocalization
-          filters:
-            branches:
-              ignore:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,7 @@ workflows:
             - rnaseq
             - rnaseq-star
             - rnaseq-pe
-            - rnaseq-sra
+            - rnaseq-misc
             - chipseq
             - references
             - colocalization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,11 +198,12 @@ variables:
   # cache load
   rnaseq-misc-step: &rnaseq-misc-step
       run:
-        name: rnaseq download from SRA
+        name: misc RNA-seq tests
         command: |
           ORIG=$(pwd)
           cd $DEPLOY
           cp -r workflows/rnaseq workflows/rnaseq-misc-test
+          cp -r workflows/rnaseq/data /tmp/data
           cd workflows/rnaseq-misc-test
           source activate lcdb-wf-test
 
@@ -210,17 +211,23 @@ variables:
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/test_sra_sampletable.tsv
 
+          rm -r data
+          cp -r /tmp/data data
           ./run_test.sh -j 1 --use-conda -k -p -r --until cutadapt \
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/test_sra_sampletable_SE_only.tsv
 
           # test strandedness, PE
+          rm -r data
+          cp -r /tmp/data data
           ./run_test.sh -j 2 --use-conda -k -p -r --until strand_check \
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/test_pe_sampletable.tsv \
             && cat strandedness.tsv
 
           # test strandedness, SE
+          rm -r data
+          cp -r /tmp/data data
           ./run_test.sh -j 2 --use-conda -k -p -r --until strand_check \
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/two_samples.tsv \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,15 +194,16 @@ variables:
             --config sampletable=$ORIG/test/test_configs/two_samples.tsv \
             --until star
   # --------------------------------------------------------------------------
-  # Quick test just to download SRA data
-  rnaseq-sra-step: &rnaseq-sra-step
+  # Various tests on RNA-seq workflow that don't warrant the overhead of a new
+  # cache load
+  rnaseq-misc-step: &rnaseq-misc-step
       run:
         name: rnaseq download from SRA
         command: |
           ORIG=$(pwd)
           cd $DEPLOY
-          cp -r workflows/rnaseq workflows/rnaseq-sra-test
-          cd workflows/rnaseq-sra-test
+          cp -r workflows/rnaseq workflows/rnaseq-misc-test
+          cd workflows/rnaseq-misc-test
           source activate lcdb-wf-test
 
           ./run_test.sh -j 1 --use-conda -k -p -r --until cutadapt \
@@ -224,8 +225,9 @@ variables:
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/two_samples.tsv \
             && cat strandedness.tsv
+
   # --------------------------------------------------------------------------
-  # Quick test to ensure PE sampletables work correctly
+  # Quick (ish) test for PE data
   rnaseq-pe-step: &rnaseq-pe-step
       run:
         name: rnaseq test PE
@@ -236,9 +238,12 @@ variables:
           cd workflows/rnaseq-pe-test
           source activate lcdb-wf-test
 
-          ./run_test.sh -j 1 --use-conda -k -p -r --until multiqc \
+          # test PE reads
+          ./run_test.sh -j 2 --use-conda -k -p -r --until multiqc \
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/test_pe_sampletable.tsv
+
+
   # --------------------------------------------------------------------------
   # Standard colocalization workflow
   colocalization-step: &colocalization-step
@@ -342,14 +347,14 @@ jobs:
       - *get-data
       - *rnaseq-star-step
 
-  rnaseq-sra:
+  rnaseq-misc:
     <<: *defaults
     steps:
       - checkout
       - *restore_cache
       - *set-path
       - *get-data
-      - *rnaseq-sra-step
+      - *rnaseq-misc-step
 
 
   rnaseq-pe:
@@ -458,7 +463,7 @@ workflows:
             branches:
               ignore:
                 - master
-      - rnaseq-sra:
+      - rnaseq-misc:
           requires:
             - initial-setup
             - pytest
@@ -500,6 +505,8 @@ workflows:
           requires:
             - rnaseq
             - rnaseq-star
+            - rnaseq-pe
+            - rnaseq-sra
             - chipseq
             - references
             - colocalization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,18 @@ variables:
           ./run_test.sh -j 1 --use-conda -k -p -r --until cutadapt \
             --configfile $ORIG/test/test_configs/override.yaml \
             --config sampletable=$ORIG/test/test_configs/test_sra_sampletable_SE_only.tsv
+
+          # test strandedness, PE
+          ./run_test.sh -j 2 --use-conda -k -p -r --until strand_check \
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/test_pe_sampletable.tsv \
+            && cat strandedness.tsv
+
+          # test strandedness, SE
+          ./run_test.sh -j 2 --use-conda -k -p -r --until strand_check \
+            --configfile $ORIG/test/test_configs/override.yaml \
+            --config sampletable=$ORIG/test/test_configs/two_samples.tsv \
+            && cat strandedness.tsv
   # --------------------------------------------------------------------------
   # Quick test to ensure PE sampletables work correctly
   rnaseq-pe-step: &rnaseq-pe-step

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -279,7 +279,7 @@ if config['aligner']['index'].startswith('star'):
         '--alignMatesGapMax 1000000 '            # max distance between mates
         '--outSAMunmapped None '                 # do not report aligned reads in output
     )
-    logfile_extensions = ['Log.progress.out', 'Log.out', 'Log.final.out']
+    logfile_extensions = ['Log.progress.out', 'Log.out', 'Log.final.out', 'Log.std.out']
 
 if config['aligner']['index'] == 'star':
 
@@ -303,17 +303,16 @@ if config['aligner']['index'] == 'star':
             prefix = output.bam.replace('.bam', '.star.')
             shell(
                 STAR_CMD + (
-                    # In contrast to pass 1, we will be keeping these BAMs --
-                    # so sort them
                     '--outSAMtype BAM SortedByCoordinate '
-                    '&> {log} '
+                    '--outStd BAM_SortedByCoordinate > {output.bam} '
+                    '2> {log} '
                 )
             )
-            shell('mv {prefix}Aligned.sortedByCoord.out.bam {output.bam}')
 
+            # move various hard-coded log files to log directory
             logfiles = expand(prefix + '{ext}', ext=logfile_extensions)
-            shell('mkdir -p {outdir}/star_log '
-                  '&& mv {logfiles} {outdir}/star_log')
+            shell('mkdir -p {outdir}/star_logs '
+                  '&& mv {logfiles} {outdir}/star_logs')
 
 if config['aligner']['index'] == 'star-twopass':
 
@@ -345,14 +344,10 @@ if config['aligner']['index'] == 'star-twopass':
                 )
             )
 
-            # STAR clutters the directory with log files -- move them to
-            # a subdirectory.
-            #
+            # move various hard-coded log files to log directory
             logfiles = expand(prefix + '{ext}', ext=logfile_extensions)
-            shell('mkdir -p {outdir}/star-pass1_log '
-                  '&& mv {logfiles} {outdir}/star-pass1_log')
-
-            shell('cat {prefix}Log.std.out >> {log} && rm {prefix}Log.std.out')
+            shell('mkdir -p {outdir}/star-pass1_logs '
+                  '&& mv {logfiles} {outdir}/star-pass1_logs')
 
 
     rule star_pass2:
@@ -384,14 +379,17 @@ if config['aligner']['index'] == 'star-twopass':
                     # Splice junction databases from all samples in the first
                     # pass.
                     '--sjdbFileChrStartEnd {input.sjout} '
-                    '&> {log} '
+                    '--outStd BAM_SortedByCoordinate > {output.bam} '
+                    '2> {log} '
                 )
             )
-            shell('mv {prefix}Aligned.sortedByCoord.out.bam {output.bam}')
 
+            # move various hard-coded log files to log directory
             logfiles = expand(prefix + '{ext}', ext=logfile_extensions)
-            shell('mkdir -p {outdir}/star-pass2_log '
-                  '&& mv {logfiles} {outdir}/star-pass2_log')
+            shell('mkdir -p {outdir}/star-pass2_logs '
+                  '&& mv {logfiles} {outdir}/star-pass2_logs')
+
+            shell('rm -r {prefix}_STARgenome')
 
 
 rule rRNA:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -159,6 +159,64 @@ if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('S
                     '&& mv {output[0]}.tmp {output[0]} '
                 )
 
+# This can be set at the command line with --config strand_check_reads=1000
+config.setdefault('strand_check_reads', 1e5)
+
+rule sample_strand_check:
+    input:
+        fastq=common.fill_r1_r2(c.sampletable, c.patterns['fastq']),
+        index=[c.refdict[c.organism][config['aligner']['tag']]['bowtie2']],
+        bed12=c.refdict[c.organism][config['gtf']['tag']]['bed12']
+    output:
+        temporary('{sample}.strandedness')
+    threads: 6
+    run:
+        prefix = aligners.prefix_from_bowtie2_index(input.index)
+        nreads = int(config['strand_check_reads']) * 4
+        if c.is_paired:
+            assert len(input.fastq) == 2
+            shell('set +o pipefail; zcat {input.fastq[0]} | head -n {nreads} > {output}.small_R1.fastq')
+            shell('set +o pipefail; zcat {input.fastq[1]} | head -n {nreads} > {output}.small_R2.fastq')
+            fastqs = f'-1 {output}.small_R1.fastq -2 {output}.small_R2.fastq '
+        else:
+            assert len(input.fastq) == 1
+            shell('set +o pipefail; zcat {input.fastq[0]} | head -n {nreads} > {output}.small_R1.fastq')
+            fastqs = f'-U {output}.small_R1.fastq '
+        shell(
+            "bowtie2 "
+            "-x {prefix} "
+            "{fastqs} "
+            '--no-unal '
+            "--threads {threads} "
+            "| samtools view -Sb - "
+            "| samtools sort - -o {output}.bam "
+        )
+        shell(
+            'infer_experiment.py -r {input.bed12} -i {output}.bam > {output} '
+            '&& rm {output}.bam {output}.small_R?.fastq'
+        )
+
+rule strand_check:
+    input:
+        expand('{sample}.strandedness', sample=SAMPLES)
+    output:
+        'strandedness.tsv'
+    run:
+        ds = []
+        for f in list(input):
+            d = {}
+            sample = f.split('.')[0]
+            d['sample'] = sample
+            for line in open(f):
+                line = line.strip()
+                toks = line.split(': ')
+                if 'explained by' in line:
+                    d[toks[0].split()[-1].replace('"', '')] = toks[-1]
+                if 'failed to determine' in line:
+                    d['undetermined'] = toks[-1]
+            ds.append(d)
+        pd.DataFrame(ds).to_csv(output[0], sep='\t', index=False)
+
 
 rule cutadapt:
     """


### PR DESCRIPTION
It's always been annoying to me to run most of the way through the workflow only to realize that the strandedness of the library was not what I originally thought. This PR adds a rule that you can run at the beginning of a project (immediately after setting up the sampletable and config). The rule does not enter the DAG; you need to explicitly ask for it from the command line.

Run it like this:

```bash
snakemake -j2 strand_check
```

Then check `strandedness.tsv` in the current working directory. For single-end, it looks something like:

```
sample      undetermined  ++,--       +-,-+
sample1     0.1099        0.4545      0.4356
sample2     0.2011        0.4090      0.3899
sample3     0.1909        0.4105      0.3985
sample4     0.1919        0.4142      0.3939
```

(see http://rseqc.sourceforge.net/#infer-experiment-py for interpretation of those headers)

This will do the following for each sample:

- subset the fastq[s]  for each sample to the number of specified reads (10k by default)
- align with bowtie2
- send directly to infer_experiment.py
- save the infer_experiment.py output in the current directory, marking it as a temp() file.

Then the `strand_check` rule aggregates these into a TS, which is `strandedness.tsv`.

If you want a different number, specify from the command line:

```bash
snakemake -j2 strand_check --config strand_check_reads=1e6
```

