### PR TITLE
try uploading artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ variables:
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
 
           # bundle up the entire directory to be used as an artifact
-          tar -zrcf downstream.tar.gz downstream/
+          tar -zcf downstream.tar.gz downstream/
 
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ variables:
       name: Setup conda
       command: |
         set -e
-        apt install -y locales-all locales
+        apt install -y locales-all locales zip
         export LC_ALL=en_US.utf8
         export LANG=en_US.utf8
         # We only do the installation if the conda environment does not already

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,11 @@ jobs:
       - *set-path
       - run:
           name: Report environment
-          command: conda env export -n lcdb-wf-test
+          command: |
+            conda env export -n lcdb-wf-test > /tmp/env.yaml
+            cat /tmp/env.yaml
+      - store_artifacts:
+          path: /tmp/env.yaml
 
 # ----------------------------------------------------------------------------
 # This section configures the dependencies across jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ variables:
       name: Setup conda
       command: |
         set -e
-        apt install -y locales-all locales zip
+        apt install -y locales-all locales
         export LC_ALL=en_US.utf8
         export LANG=en_US.utf8
         # We only do the installation if the conda environment does not already
@@ -172,8 +172,8 @@ variables:
           source activate lcdb-wf-test-r
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
 
-          # zip up the entire directory to be used as an artifact
-          zip -r downstream.zip downstream/
+          # bundle up the entire directory to be used as an artifact
+          tar -zrcf downstream.tar.gz downstream/
 
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK
@@ -327,7 +327,7 @@ jobs:
       - *get-data
       - *rnaseq-step
       - store_artifacts:
-          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream.zip
+          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream.tar.gz
       - store_artifacts:
           path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream/rnaseq.html
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,8 +411,11 @@ jobs:
           command: |
             conda env export -n lcdb-wf-test > /tmp/env.yaml
             cat /tmp/env.yaml
+            conda env export -n lcdb-wf-test-r > /tmp/env-r.yaml
       - store_artifacts:
           path: /tmp/env.yaml
+      - store_artifacts:
+          path: /tmp/env-r.yaml
 
 # ----------------------------------------------------------------------------
 # This section configures the dependencies across jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,9 @@ variables:
           source activate lcdb-wf-test-r
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
 
+          # zip up the entire directory to be used as an artifact
+          zip -r downstream.zip downstream/
+
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK
   rnaseq-star-step: &rnaseq-star-step
@@ -322,8 +325,11 @@ jobs:
       - *get-data
       - *rnaseq-step
       - store_artifacts:
-          # env vars not availabe here, but $DEPLOY is /tmp/lcdb-wf-test
-          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream
+          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream.zip
+      - store_artifacts:
+          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream/rnaseq.html
+      - store_artifacts:
+          path: /tmp/lcdb-wf-test/workflows/rnaseq/data/rnaseq_aggregation/multiqc.html
 
   rnaseq-star:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,8 @@ jobs:
       - *set-path
       - *get-data
       - *chipseq-step
+      - store_artifacts:
+          path: /tmp/lcdb-wf-test/workflows/chipseq/data/chipseq_aggregation/multiqc.html
 
   chipseq-regression:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ variables:
   # --------------------------------------------------------------------------
   # Standard RNA-seq workflow
   rnaseq-step: &rnaseq-step
-    - run:
+      run:
         name: rnaseq workflow
         command: |
           cd $DEPLOY/workflows/rnaseq
@@ -172,8 +172,6 @@ variables:
           source activate lcdb-wf-test-r
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
 
-    - store_artifacts:
-        path: $DEPLOY/workflows/rnaseq/downstream
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK
   rnaseq-star-step: &rnaseq-star-step
@@ -323,6 +321,8 @@ jobs:
       - *set-path
       - *get-data
       - *rnaseq-step
+      - store_artifacts:
+          path: $DEPLOY/workflows/rnaseq/downstream
 
   rnaseq-star:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,9 @@ variables:
           # outside the context of the Snakefile.
           source activate lcdb-wf-test-r
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
+
+      store_artifacts:
+        path: $DEPLOY/workflows/rnaseq/downstream
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK
   rnaseq-star-step: &rnaseq-star-step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ variables:
         apt install -y rsync
 
         # Deploy to the new directory, so we are testing the real-world case of post-deployment.
-        # Note that $DEPLOY is set in the "set-paths" step configured below.
+        # Note that $DEPLOY is set in the "set-paths" step configured above.
         python deploy.py --flavor full --dest $DEPLOY
 
         # Separately copy over some test-specific files
@@ -322,7 +322,8 @@ jobs:
       - *get-data
       - *rnaseq-step
       - store_artifacts:
-          path: $DEPLOY/workflows/rnaseq/downstream
+          # env vars not availabe here, but $DEPLOY is /tmp/lcdb-wf-test
+          path: /tmp/lcdb-wf-test/workflows/rnaseq/downstream
 
   rnaseq-star:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ variables:
   # --------------------------------------------------------------------------
   # Standard RNA-seq workflow
   rnaseq-step: &rnaseq-step
-      run:
+    - run:
         name: rnaseq workflow
         command: |
           cd $DEPLOY/workflows/rnaseq
@@ -172,7 +172,7 @@ variables:
           source activate lcdb-wf-test-r
           Rscript -e "rmarkdown::render('downstream/rnaseq.Rmd')"
 
-      store_artifacts:
+    - store_artifacts:
         path: $DEPLOY/workflows/rnaseq/downstream
   # --------------------------------------------------------------------------
   # Quick test on just two samples to make sure STAR works OK


### PR DESCRIPTION
This PR takes advantage of the CircleCI feature to [upload artifacts](https://circleci.com/docs/2.0/artifacts/) that can be downloaded from the respective test's artifacts tab.

Currently:

- chipseq test uploads `multiqc.html`

- rnaseq test uploads 
  - a zip of the entire `downstream` directory
  - the rendered `rnaseq.html`
  - `multiqc.html`

- report-env job uploads the `env.yaml` of the successfully-created environment (and the `env-r.yaml` of the successfully-created R environment).

It may be possible to build the docs such that they pull the latest artifacts, so that the various reports in their most recent state are hosted directly in the docs as examples.