### PR TITLE
DAG simplification

### DIFF
--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -64,20 +64,9 @@ helpers.preflight(config)
 
 # See "patterns and targets" in the documentation for what's going on here.
 final_targets = utils.flatten((
-    c.targets['bam'],
-    utils.flatten(c.targets['fastqc']),
-    utils.flatten(c.targets['libsizes']),
-    [c.targets['fastq_screen']],
-    [c.targets['libsizes_table']],
     [c.targets['multiqc']],
-    utils.flatten(c.targets['markduplicates']),
-    utils.flatten(c.targets['bigwig']),
     utils.flatten(c.targets['peaks']),
-    utils.flatten(c.targets['merged_techreps']),
-    utils.flatten(c.targets['fingerprint']),
     utils.flatten(c.targets['bigbed']),
-    utils.flatten(c.targets['multibigwigsummary']),
-    utils.flatten(c.targets['plotcorrelation']),
 ))
 
 if 'merged_bigwigs' in config:
@@ -415,7 +404,8 @@ rule multiqc:
             utils.flatten(c.targets['markduplicates']) +
             utils.flatten(c.targets['fingerprint']) +
             utils.flatten(c.targets['peaks']) +
-            utils.flatten(c.targets['fastq_screen'])
+            utils.flatten(c.targets['fastq_screen']) +
+            utils.flatten(c.targets['plotcorrelation'])
         ),
         config='config/multiqc_config.yaml'
     output:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -53,20 +53,7 @@ def wrapper_for(path):
 
 # See "patterns and targets" in the documentation for what's going on here.
 final_targets = utils.flatten((
-    c.targets['bam'],
-    utils.flatten(c.targets['fastqc']),
-    utils.flatten(c.targets['libsizes']),
-    [c.targets['fastq_screen']],
-    [c.targets['libsizes_table']],
-    [c.targets['rrna_percentages_table']],
     [c.targets['multiqc']],
-    utils.flatten(c.targets['featurecounts']),
-    utils.flatten(c.targets['rrna']),
-    utils.flatten(c.targets['markduplicates']),
-    utils.flatten(c.targets['salmon']),
-    utils.flatten(c.targets['preseq']),
-    utils.flatten(c.targets['rseqc']),
-    utils.flatten(c.targets['collectrnaseqmetrics']),
     utils.flatten(c.targets['bigwig']),
 ))
 


### PR DESCRIPTION
The ChIP-seq and RNA-seq workflows had many intermediate files as inputs to the `targets` rule. This removes those and only includes the multiqc and the bigwig/bigbed creation.

I'm not sure if this is the right thing to do. It definitely simplifies the DAG. But users just starting out may get confused as to why, after adding a sample, nothing needs to be re-run. That is, before this PR adding a sample to the sampletable would add a BAM to the inputs of the `targets` rule, and would sort of force the rest of the DAG for that sample. But after this PR, if multiqc.html already exists then no jobs would be run by default. Instead they'd need to force-run the multiqc rule to trigger the inputs and therefore the rest of the DAG.
