### PR TITLE
fix circleci container setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ variables:
       name: Setup conda
       command: |
         set -e
+        apt update
         apt install -y locales-all locales
         export LC_ALL=en_US.utf8
         export LANG=en_US.utf8


### PR DESCRIPTION
Just found out over on https://github.com/lcdb/lcdb-wf/pull/347 that circleci tests are failing due to something going on with the container setup. This PR will be used to get that working again, and then squashed to target v1.9rc branch.