### PR TITLE
require contrast names include sorting index

### DIFF
--- a/docs/rnaseq-rmd.rst
+++ b/docs/rnaseq-rmd.rst
@@ -268,8 +268,10 @@ its own chunk **according to the following rules**:
 - the chunk name must start with ``results_``
 - the chunk is cached
 - the chunk depends on the ``'dds_list'`` chunk
-- the variable name starts with ``contr_``, and the rest of the variable name
-  will be used as the name in the list
+- the variable name starts with ``contr_[index]_``, and the rest of the variable name
+  will be used as the name in the list. index is a string, containing 1 or more alphanumeric
+  characters, and will be used as a sorting index for contrasts when generating output files.
+  Note that the index string cannot contain "_".
 
 Our example would look like the following. Note that we're showing the chunks
 here because that will be come meaningful in a moment. They are shown as
@@ -278,7 +280,7 @@ comments here just to get the syntax highlighting to look OK.
 .. code-block:: r
 
     # ```{r results_01, dependson='dds_list', cache=TRUE}
-    contr_ko.vs.wt <- lcdbwf::make_results(
+    contr_1_ko.vs.wt <- lcdbwf::make_results(
       dds_name='main',
       label='Using all samples',
       contrast=c('genotype', 'KO', 'WT')
@@ -286,7 +288,7 @@ comments here just to get the syntax highlighting to look OK.
     # ```
 
     # ```{r results_02, dependson='dds_list', cache=TRUE}
-    contr_no.rep.4 <- lcdbwf::make_results(
+    contr_2a_no.rep.4 <- lcdbwf::make_results(
       dds_name='no.rep.4',
       label='Removing replicate 4 and using ashr for shrinkage',
       contrast=c('genotype', 'KO', 'WT'),
@@ -330,9 +332,13 @@ above <rules>`. By following those rules, the following becomes possible:
 - we can detect all chunks creating results by looking for ``results_`` in the
   chunk name and automatically inject these into dependencies of future chunks.
 - we can detect all results objects created by looking for variables starting
-  with ``contr_``
+  with ``contr_[index]_``
 - we can assemble all results objects into a list, and name each item in the
-  list according to its variable name (minus the ``contr_``).
+  list according to its variable name (minus the ``contr_[index]_``).
+- we can alter the order of contrasts by simply modifying the index string in a single chunk.
+  For example, if we have three contrasts contr_1_ko.vs.wt, contr_2_no.rep.4, and contr_3_no.rep.3, 
+  we can change the order of contrasts simply by modifying one index string (ex: change contr_3_no.rep.3 to
+  contr_1a_no.rep.3).
 
 The ``assemble_variables`` chunk does all of this. The end result of this chunk
 is a list of lists that is used by functions in the `lcdbwf` R package for

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -214,9 +214,10 @@ there are more tabs for the various output.
 # To take advantage of caching:
 #   - create each list in a different chunk
 #   - ensure chunk name starts with "results_"
-#   - ensure list name starts with "contr_NN_". The rest of the name will be used
-#     as a readable label for each constrast. NN should be a 2 digit number
-#     (ex: contr_01_*) that will dictate the order of contrasts in output files.
+#   - ensure list name starts with "contr_[index]_". The rest of the name will be used
+#     as a readable label for each constrast. [index] is an alphanumeric string 
+#     (ex: contr_01_* or contr_2b_*) that will be used to sort contrasts for output files.
+#     The index string must contain at least 1 character and cannot contain "_"
 #
 # This will need substantial editing.
 #
@@ -253,7 +254,7 @@ contr_02_lfc1 <- lcdbwf::make_results(
 # Example 3:
 #   - demonstrates using normal shrinkage
 #   - demonstrates how to use salmon
-contr_03_salmon <- lcdbwf::make_results(
+contr_03a_salmon <- lcdbwf::make_results(
   dds_name="salmon",
   contrast=c("group", "treatment", "control"),
   type="normal",
@@ -264,7 +265,7 @@ contr_03_salmon <- lcdbwf::make_results(
 ```{r results_04, dependson='dds_list', cache=TRUE}
 # Example 4:
 #   - like example 3, but kallisto instead of salmon
-contr_04_kallisto <- lcdbwf::make_results(
+contr_03_kallisto <- lcdbwf::make_results(
   dds_name="kallisto",
   contrast=c('group', 'treatment', 'control'),
   type='normal',
@@ -274,7 +275,7 @@ contr_04_kallisto <- lcdbwf::make_results(
 
 
 ```{r assemble_variables, cache=TRUE, config=config$annotation, dependson=knitr::all_labels()[grepl("^results_", knitr::all_labels())]}
-res_list <- lcdbwf::collect_objects("^contr_[0-9]{2}_")
+res_list <- lcdbwf::collect_objects("^contr_[^_]+_")
 res_list <- lcdbwf::attach_extra(res_list, config)
 ```
 

--- a/workflows/rnaseq/downstream/rnaseq.Rmd
+++ b/workflows/rnaseq/downstream/rnaseq.Rmd
@@ -214,8 +214,9 @@ there are more tabs for the various output.
 # To take advantage of caching:
 #   - create each list in a different chunk
 #   - ensure chunk name starts with "results_"
-#   - ensure list name starts with "contr_". The rest of the name will be used
-#     as a label to sort results and create output files.
+#   - ensure list name starts with "contr_NN_". The rest of the name will be used
+#     as a readable label for each constrast. NN should be a 2 digit number
+#     (ex: contr_01_*) that will dictate the order of contrasts in output files.
 #
 # This will need substantial editing.
 #
@@ -228,7 +229,7 @@ there are more tabs for the various output.
 #  - demonstrates creating and manipulating coefficients
 control <- lcdbwf::dds_coefs('main', group=='control')
 treatment <- lcdbwf::dds_coefs('main', group=='treatment')
-contr_main <- lcdbwf::make_results(
+contr_01_main <- lcdbwf::make_results(
   dds_name='main',
   label='LFC>0',
   contrast=treatment - control,
@@ -239,7 +240,7 @@ contr_main <- lcdbwf::make_results(
 ```{r results_02, dependson='dds_list', cache=TRUE}
 # Example 2:
 #  - demonstrates using a log2FoldChange threshold
-contr_lfc1 <- lcdbwf::make_results(
+contr_02_lfc1 <- lcdbwf::make_results(
   dds_name="no_rep4",
   contrast=c("group", "treatment", "control"),
   lfcThreshold=1,
@@ -252,7 +253,7 @@ contr_lfc1 <- lcdbwf::make_results(
 # Example 3:
 #   - demonstrates using normal shrinkage
 #   - demonstrates how to use salmon
-contr_salmon <- lcdbwf::make_results(
+contr_03_salmon <- lcdbwf::make_results(
   dds_name="salmon",
   contrast=c("group", "treatment", "control"),
   type="normal",
@@ -263,7 +264,7 @@ contr_salmon <- lcdbwf::make_results(
 ```{r results_04, dependson='dds_list', cache=TRUE}
 # Example 4:
 #   - like example 3, but kallisto instead of salmon
-contr_kallisto <- lcdbwf::make_results(
+contr_04_kallisto <- lcdbwf::make_results(
   dds_name="kallisto",
   contrast=c('group', 'treatment', 'control'),
   type='normal',
@@ -273,7 +274,7 @@ contr_kallisto <- lcdbwf::make_results(
 
 
 ```{r assemble_variables, cache=TRUE, config=config$annotation, dependson=knitr::all_labels()[grepl("^results_", knitr::all_labels())]}
-res_list <- lcdbwf::collect_objects("^contr_")
+res_list <- lcdbwf::collect_objects("^contr_[0-9]{2}_")
 res_list <- lcdbwf::attach_extra(res_list, config)
 ```
 


### PR DESCRIPTION
Previously, v1.9rc required contrast names to follow the format `contr_[name]`, where [name] was used to alphabetically sort the output summary tables. To add flexibility, this branch requires the format `contr_NN_[name]`, where NN is a two-digit numeric index used to sort the contrasts. Users can modify NN to alter the order in which the contrast appears in output data tables. Documentation & example contrasts are update to reflect this change, as well. Addresses Issue #359 