### PR TITLE
support fixing group permissons on AnnotationHub cache

### DIFF
--- a/lib/lcdbwf/R/annotations.R
+++ b/lib/lcdbwf/R/annotations.R
@@ -39,7 +39,7 @@ get_annotation_hub <- function(config, localHub=NULL, force=NULL, cache=NULL){
   # will be set on BiocFileCache.sqlite and BiocFileCache.sqlite.LOCK to be
   # read/write for both user and group.
   if (config$main$group_permissions){
-    files <- dir(cache)
+    files <- dir(cache, full.names=TRUE)
     files <- files[grep('BiocFileCache.sqlite', files)]
     Sys.chmod(files, mode="0660", use_umask=TRUE)
   }

--- a/lib/lcdbwf/R/annotations.R
+++ b/lib/lcdbwf/R/annotations.R
@@ -31,6 +31,19 @@ get_annotation_hub <- function(config, localHub=NULL, force=NULL, cache=NULL){
     localHub=localHub,
     cache=cache
   )
+
+  # AnnotationHub uses a safe permissions approach, setting the AnnotationHub
+  # lock file to be only visible by the creating user and the cache database to
+  # be read-only for the group. However, this can cause permission errors when
+  # working in a group setting. If this setting is TRUE, then the permissions
+  # will be set on BiocFileCache.sqlite and BiocFileCache.sqlite.LOCK to be
+  # read/write for both user and group.
+  if (config$main$group_permissions){
+    files <- dir(cache)
+    files <- files[grep('BiocFileCache.sqlite', files)]
+    Sys.chmod(files, mode="0660", use_umask=TRUE)
+  }
+
   return(ah)
 }
 

--- a/workflows/rnaseq/downstream/config.yaml
+++ b/workflows/rnaseq/downstream/config.yaml
@@ -50,6 +50,14 @@ main:
   # to TRUE.
   force_intersect: TRUE
 
+  # AnnotationHub uses a safe permissions approach, setting the AnnotationHub
+  # lock file to be only visible by the creating user and the cache database to
+  # be read-only for the group. If this setting is TRUE, then the permissions
+  # will be set on BiocFileCache.sqlite and BiocFileCache.sqlite.LOCK to be
+  # read/write for both user and group.
+  group_permissions: TRUE
+
+
 # PLOTTING ---------------------------------------------------------------------
 # This section configures plotting options for PCA, clustered heatmap, and
 # functional enrichment plots.


### PR DESCRIPTION
This addresses #357 by allowing permissions of AnnotationHub cache files, as discussed at https://github.com/Bioconductor/AnnotationHub/issues/31. It leaves the lockfile in place, but before returning the AnnotationHub object it modifies permissions to 660 (if specified in the config).