### PR TITLE
Fix multiqc_config.yaml

### DIFF
--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -35,6 +35,8 @@ sp:
 module_order:
     - fastqc:
         name: 'FastQC (raw)'
+        path_filters_exclude:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
         path_filters:
             - '*.fastq.gz_fastqc.zip'
     - libsizes_table

--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -13,6 +13,7 @@ extra_fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+  - '_R2'
 
 
 # Modify the module search patterns to match what we're creating in the

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -49,6 +49,8 @@ fn_ignore_files:
 module_order:
     - fastqc:
         name: 'FastQC (raw)'
+        path_filters_exclude:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
         path_filters:
             - '*.fastq.gz_fastqc.zip'
     - libsizes_table


### PR DESCRIPTION
Fix an old bug where for the raw fastqs randomly get either raw or trimmed data. For example, looking at the first 3 columns of `data/rnaseq_aggregation/multiqc_data/multiqc_fastqc.txt` see the mixture of files selected:
```
$ cut -f1-4 multiqc_fastqc.txt | tab | head
Sample         Filename                            File type                Encoding
ptc-24h-0gy-1  ptc-24h-0gy-1_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-2  ptc-24h-0gy-2_R1.fastq.gz           Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-3  ptc-24h-0gy-3_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-4  ptc-24h-0gy-4_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-5  ptc-24h-0gy-5_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-6  ptc-24h-0gy-6_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-7  ptc-24h-0gy-7_R1.fastq.gz           Conventional base calls  Sanger / Illumina 1.9
ptc-24h-0gy-8  ptc-24h-0gy-8_R1.fastq.gz           Conventional base calls  Sanger / Illumina 1.9
ptc-24h-2gy-1  ptc-24h-2gy-1_R1.cutadapt.fastq.gz  Conventional base calls  Sanger / Illumina 1.9
```
And the same incorrect data propagates into `multiqc.html`.