### PR TITLE
V1.10.2rc

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+v1.10.2
+-------
+
+Minor bugfix release.
+
+- Fix multiqc configs so that they coorectly ignore any cutadapt fastqc zips when building the raw fastq section
+- Fix multiqc config for chipseq so it correctly cleans the ``_R2`` extension to better support PE ChIP-seq-like workflows
+- Fix functional enrichment label truncation to ensure that truncated labels are unique
+
 v1.10.1
 -------
 This is a bugfix and minor patch release.

--- a/lib/lcdbwf/R/functional_enrichment.R
+++ b/lib/lcdbwf/R/functional_enrichment.R
@@ -610,6 +610,7 @@ truncate <- function(obj, truncate_to){
     return(x)
   }
   obj@result$Description <- sapply(obj@result$Description, f)
+  obj@result$Description <- make.unique(obj@result$Description)
   return(obj)
 }
 

--- a/workflows/chipseq/config/multiqc_config.yaml
+++ b/workflows/chipseq/config/multiqc_config.yaml
@@ -13,6 +13,7 @@ extra_fn_clean_exts:
   - '.fastq'
   - '.salmon'
   - '_R1'
+  - '_R2'
 
 
 # Modify the module search patterns to match what we're creating in the
@@ -35,6 +36,8 @@ sp:
 module_order:
     - fastqc:
         name: 'FastQC (raw)'
+        path_filters_exclude:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
         path_filters:
             - '*.fastq.gz_fastqc.zip'
     - libsizes_table

--- a/workflows/rnaseq/config/multiqc_config.yaml
+++ b/workflows/rnaseq/config/multiqc_config.yaml
@@ -49,6 +49,8 @@ fn_ignore_files:
 module_order:
     - fastqc:
         name: 'FastQC (raw)'
+        path_filters_exclude:
+            - '*.cutadapt.fastq.gz_fastqc.zip'
         path_filters:
             - '*.fastq.gz_fastqc.zip'
     - libsizes_table


### PR DESCRIPTION
- fix multiqc configs (#374, superceded by #375)
- fix functional enrichment to ensure truncated labels are unique