### PR TITLE
Update Snakefile - add `--countReadPairs` for PE featureCounts

### DIFF
--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -601,7 +601,7 @@ rule featurecounts:
         # NOTE: By default, we use -p for paired-end
         p_arg = ''
         if c.is_paired:
-            p_arg = '-p '
+            p_arg = '-p --countReadPairs '
 
         strand_arg = helpers.strand_arg_lookup(
             c, {


### PR DESCRIPTION
# v2.0.1:
```
 -p                  If specified, fragments (or templates) will be counted
                      instead of reads. This option is only applicable for
                      paired-end reads; single-end reads are always counted as
                      reads.

  -B                  Only count read pairs that have both ends aligned.
...
```
# v2.0.3:
```
  -p                  Specify that input data contain paired-end reads. To
                      perform fragment counting (ie. counting read pairs), the
                      '--countReadPairs' parameter should also be specified in
                      addition to this parameter.

  --countReadPairs    Count read pairs (fragments) instead of reads. This option
                      is only applicable for paired-end reads.

  -B                  Only count read pairs that have both ends aligned.
...
```