### PR TITLE
added Error documentation section to rnaseq-rmd.rst and hyperlnked to it in helpers.R error message

### DIFF
--- a/docs/rnaseq-rmd.rst
+++ b/docs/rnaseq-rmd.rst
@@ -557,15 +557,14 @@ Error: "Found duplicate names after removing pattern ^contr_[^_]+_"
          Even if the change is undone and the environment is cleared,
          the error may persist. For example, changing ``contr_01``
          in ``results_01`` to ``contr_05`` and then reknitting the file
-         will cause the R environment to contain both ``contr_01`` and 
+         will cause the R environment to contain both ``contr_01`` and
          ``contr_05`` patterns after that chunk is loaded, leading to
          this error.
 
    Solution:
-      - Clear all cache and R environment objects before the
-        ``assemble_variables`` chunk. Quit R without saving the
-        workspace, delete the .RData file, remove all ``rnaseq_cache`` files,
-        open rnaseq.Rmd and knit again.
+      - Clear all cache and R environment objects.
+        Quit R without saving the workspace, delete the .RData file,
+        remove the ``rnaseq_cache`` directory, open rnaseq.Rmd and re-knit.
 
 Glossary
 --------

--- a/lib/lcdbwf/R/helpers.R
+++ b/lib/lcdbwf/R/helpers.R
@@ -81,7 +81,7 @@ collect_objects <- function(pattern, fixed=FALSE){
   # If there was a wildcard in the pattern there is a risk that the modified
   # names are no longer unique
   if (length(unique(modified_names)) != length(var_names)){
-    stop(paste("Found duplicate names after removing pattern", pattern))
+    stop(paste("Found duplicate names after removing pattern", pattern, "see https://lcdb.github.io/lcdb-wf/rnaseq-rmd.html#Errors for details"))
   }
   names(obj_list) <- modified_names
   return(obj_list)


### PR DESCRIPTION
stop(paste("Found duplicate names after removing pattern", pattern))
->
stop(paste("Found duplicate names after removing pattern", pattern, "see https://lcdb.github.io/lcdb-wf/rnaseq-rmd.html#Errors for details"))

closes #395