### PR TITLE
Fix unused r1_only parameter

### DIFF
--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -64,7 +64,7 @@ if config.get('merged_bigwigs', None):
     final_targets.extend(utils.flatten(c.targets['merged_bigwig']))
 
 
-def render_r1_r2(pattern, r1_only=False):
+def render_r1_r2(pattern):
     return expand(pattern, sample='{sample}', n=c.n)
 
 def r1_only(pattern):


### PR DESCRIPTION
The render_r1_r2() function in the rnaseq Snakefile had an unused r1_only=False parameter which was removed