### PR TITLE
Move strandednes in params

### DIFF
--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -70,7 +70,7 @@ if config.get('merged_bigwigs', None):
     final_targets.extend(utils.flatten(c.targets['merged_bigwig']))
 
 
-def render_r1_r2(pattern, r1_only=False):
+def render_r1_r2(pattern):
     return expand(pattern, sample='{sample}', n=c.n)
 
 def r1_only(pattern):

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -594,6 +594,15 @@ rule featurecounts:
         counts='{sample_dir}/rnaseq_aggregation/featurecounts.txt'
     log:
         '{sample_dir}/rnaseq_aggregation/featurecounts.txt.log'
+    params:
+
+        strand_arg = helpers.strand_arg_lookup(
+            c, {
+                'unstranded': '-s0 ',
+                'fr-firststrand': '-s2 ',
+                'fr-secondstrand': '-s1 ',
+            }
+        )
     threads: 8
     resources:
         mem_mb=gb(16),
@@ -604,17 +613,10 @@ rule featurecounts:
         if c.is_paired:
             p_arg = '-p --countReadPairs '
 
-        strand_arg = helpers.strand_arg_lookup(
-            c, {
-                'unstranded': '-s0 ',
-                'fr-firststrand': '-s2 ',
-                'fr-secondstrand': '-s1 ',
-            }
-        )
 
         shell(
             'featureCounts '
-            '{strand_arg} '
+            '{params.strand_arg} '
             '{p_arg} '
             '-T {threads} '
             '-a {input.annotation} '
@@ -771,6 +773,13 @@ rule collectrnaseqmetrics:
         # config.
         java_args='-Xmx20g'
         # java_args='-Xmx2g'  # [TEST SETTINGS -1]
+
+        strand_arg = helpers.strand_arg_lookup(
+            c, {
+                'unstranded': 'STRAND=NONE ',
+                'fr-firststrand': 'STRAND=SECOND_READ_TRANSCRIPTION_STRAND ',
+                'fr-secondstrand': 'STRAND=FIRST_READ_TRANSCRIPTION_STRAND ',
+            }
     log:
         c.patterns['collectrnaseqmetrics']['metrics'] + '.log'
     threads: 1
@@ -778,18 +787,12 @@ rule collectrnaseqmetrics:
         mem_mb=gb(32),
         runtime=autobump(hours=2)
     run:
-        strand_arg = helpers.strand_arg_lookup(
-            c, {
-                'unstranded': 'STRAND=NONE ',
-                'fr-firststrand': 'STRAND=SECOND_READ_TRANSCRIPTION_STRAND ',
-                'fr-secondstrand': 'STRAND=FIRST_READ_TRANSCRIPTION_STRAND ',
-            }
         )
         shell(
             'picard '
             '{params.java_args} '
             'CollectRnaSeqMetrics '
-            '{strand_arg} '
+            '{params.strand_arg} '
             'VALIDATION_STRINGENCY=LENIENT '
             'REF_FLAT={input.refflat} '
             'INPUT={input.bam} '
@@ -871,6 +874,13 @@ rule kallisto:
     params:
         index_dir=os.path.dirname(c.refdict[c.organism][config['kallisto']['tag']]['kallisto']),
         outdir=os.path.dirname(c.patterns['kallisto'])
+        strand_arg = helpers.strand_arg_lookup(
+            c, {
+                'unstranded': '',
+                'fr-firststrand': '--rf-stranded',
+                'fr-secondstrand': '--fr-stranded',
+            }
+        )
     log:
         c.patterns['kallisto'] + '.log'
     threads:
@@ -887,15 +897,6 @@ rule kallisto:
             # and standard deviation here
             se_args = '--single --fragment-length 300 --sd 20 '
             assert len(input.fastq) == 1
-
-        strand_arg = helpers.strand_arg_lookup(
-            c, {
-                'unstranded': '',
-                'fr-firststrand': '--rf-stranded',
-                'fr-secondstrand': '--fr-stranded',
-            }
-        )
-
         shell(
             'kallisto quant '
             '--index {input.index} '
@@ -905,7 +906,7 @@ rule kallisto:
             '--bias '
             '--threads {threads} '
             '{se_args} '
-            '{strand_arg} '
+            '{params.strand_arg} '
             '{input.fastq} '
             '&> {log}'
         )
@@ -987,7 +988,7 @@ rule bigwig_neg:
         runtime=autobump(hours=2)
     log:
         c.patterns['bigwig']['neg'] + '.log'
-    run:
+    params:
         strand_arg = helpers.strand_arg_lookup(
             c, {
                 'unstranded': '',
@@ -995,13 +996,14 @@ rule bigwig_neg:
                 'fr-secondstrand': '--filterRNAstrand forward ',
             }
         )
+    run:
         shell(
             'bamCoverage '
             '--bam {input.bam} '
             '-o {output} '
             '-p {threads} '
             '{BAMCOVERAGE_ARGS} '
-            '{strand_arg} '
+            '{params.strand_arg} '
             '&> {log}'
         )
 
@@ -1020,8 +1022,7 @@ rule bigwig_pos:
         runtime=autobump(hours=2)
     log:
         c.patterns['bigwig']['pos'] + '.log'
-
-    run:
+    params:
         strand_arg = helpers.strand_arg_lookup(
             c, {
                 'unstranded': '',
@@ -1029,13 +1030,15 @@ rule bigwig_pos:
                 'fr-secondstrand': '--filterRNAstrand reverse ',
             }
         )
+
+    run:
         shell(
             'bamCoverage '
             '--bam {input.bam} '
             '-o {output} '
             '-p {threads} '
             '{BAMCOVERAGE_ARGS} '
-            '{strand_arg} '
+            '{params.strand_arg} '
             '&> {log}'
         )
 

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -64,7 +64,7 @@ if config.get('merged_bigwigs', None):
     final_targets.extend(utils.flatten(c.targets['merged_bigwig']))
 
 
-def render_r1_r2(pattern, r1_only=False):
+def render_r1_r2(pattern):
     return expand(pattern, sample='{sample}', n=c.n)
 
 def r1_only(pattern):


### PR DESCRIPTION
Move the assignment of strand_arg into params for tools that need strandedness so that --rerun-trigger will detect changes to strandedness configuration and re-run those rules
