### PR TITLE
Change SRA fastq directory

### DIFF
--- a/lib/patterns_targets.py
+++ b/lib/patterns_targets.py
@@ -9,6 +9,7 @@ import yaml
 from . import common
 from . import chipseq
 from . import helpers
+from snakemake.io import expand
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -116,14 +117,9 @@ class RNASeqConfig(SeqConfig):
         # If the sampletable is from an sra metadata table, then we need to set the value of
         # 'orig_filename' for each of the samples to where the fastq was downloaded
         if self.is_sra:
-            self.sampletable['orig_filename'] = None
-            for i in range(len(self.sampletable)):
-                for j in range(len(self.targets['sra_fastq'])):
-                    if self.sampletable.iloc[i, self.sampletable.columns.get_loc('samplename')] \
-                            in self.targets['sra_fastq'][j]:
-                        self.sampletable.iloc[i, self.sampletable.columns.get_loc('orig_filename')] \
-                            = self.targets['sra_fastq'][j]
-                        break
+            self.sampletable['orig_filename'] = expand(self.patterns["sra_fastq"], sample=self.samples, n=1)
+            if self.is_paired:
+                self.sampletable['orig_filename_R2'] = expand(self.patterns["sra_fastq"], sample=self.samples, n=2)
 
         # Then the aggregation
         if self.patterns_by_aggregation is not None and 'merged_bigwigs' in self.config:

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -76,6 +76,30 @@ rule targets:
     """
     input: final_targets
 
+if c.is_sra:
+
+    # Convert the sampletable to be indexed by the first column, for
+    # convenience in generating the input/output filenames.
+    _st = c.sampletable.set_index(c.sampletable.columns[0])
+
+    rule fastq_dump:
+        output:
+            fastq=render_r1_r2(c.patterns['sra_fastq'])
+        log:
+            render_r1_only(c.patterns['sra_fastq'])[0] + '.log'
+        params:
+            is_paired=c.is_paired,
+            sampletable=_st,
+            # limit = 100000, # [TEST SETTINGS]
+        resources:
+            mem_mb=gb(1),
+            disk_mb=autobump(gb=1),
+            runtime=autobump(hours=2)
+        conda:
+            '../../wrappers/wrappers/fastq-dump/environment.yaml'
+        script:
+            wrapper_for('fastq-dump/wrapper.py')
+
 if 'orig_filename' in c.sampletable.columns:
 
     localrules: symlinks, symlink_targets
@@ -114,31 +138,6 @@ if 'orig_filename' in c.sampletable.columns:
 
     rule symlink_targets:
         input: c.targets['fastq']
-
-
-if 'Run' in c.sampletable.columns and sum(c.sampletable['Run'].str.startswith('SRR')) > 0:
-
-    # Convert the sampletable to be indexed by the first column, for
-    # convenience in generating the input/output filenames.
-    _st = c.sampletable.set_index(c.sampletable.columns[0])
-
-    rule fastq_dump:
-        output:
-            fastq=render_r1_r2(c.patterns['fastq'])
-        log:
-            render_r1_only(c.patterns['fastq'])[0] + '.log'
-        params:
-            is_paired=c.is_paired,
-            sampletable=_st,
-            # limit = 100000, # [TEST SETTINGS]
-        resources:
-            mem_mb=gb(1),
-            disk_mb=autobump(gb=1),
-            runtime=autobump(hours=2)
-        conda:
-            '../../wrappers/wrappers/fastq-dump/environment.yaml'
-        script:
-            wrapper_for('fastq-dump/wrapper.py')
 
 # This can be set at the command line with --config strand_check_reads=1000
 config.setdefault('strand_check_reads', 1e5)

--- a/workflows/rnaseq/config/rnaseq_patterns.yaml
+++ b/workflows/rnaseq/config/rnaseq_patterns.yaml
@@ -3,6 +3,7 @@ strand_check:
   bam: 'strand_check/{sample}/{sample}.strandedness.bam'
   tsv: 'strand_check/{sample}/{sample}.strandedness'
 fastq: 'data/rnaseq_samples/{sample}/{sample}_R{n}.fastq.gz'
+sra_fastq: 'original_data/sra_samples/{sample}/{sample}_R{n}.fastq.gz'
 cutadapt: 'data/rnaseq_samples/{sample}/{sample}_R{n}.cutadapt.fastq.gz'
 bam: 'data/rnaseq_samples/{sample}/{sample}.cutadapt.bam'
 fastqc:


### PR DESCRIPTION
Change the directory where SRA fastq files are downloaded and add the 'orig_filename' column to the config object for each sample so that the rest of the workflow works correctly