### PR TITLE
Fix relative path issue with paths in config

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -64,13 +64,13 @@ def resolve_config(config, workdir=None):
     if isinstance(config, str):
         config = yaml.load(open(config), Loader=yaml.FullLoader)
 
-    def rel(pth):
-        if workdir is None or os.path.isabs(pth):
+    def abs_path(pth):
+        if os.path.isabs(pth):
             return pth
         return os.path.join(workdir, pth)
     for key in PATH_KEYS:
-        if key in config:
-            config[key] = rel(config[key])
+        if key in config and workdir:
+            config[key] = abs_path(config[key])
     return config
 
 

--- a/lib/patterns_targets.py
+++ b/lib/patterns_targets.py
@@ -46,17 +46,17 @@ class SeqConfig(object):
             as relative to `workdir`
         """
         self.path = None
-        self.workdir = '.'
+        self.workdir = None
         if workdir is not None:
-            config = os.path.join(workdir, config)
             patterns = os.path.join(workdir, patterns)
             self.workdir = workdir
 
         if isinstance(config, str):
             self.path = config
+            config = os.path.join(workdir, config)
 
         self.config = common.load_config(
-            common.resolve_config(config, workdir))
+            common.resolve_config(config, self.workdir))
 
         stranded = self.config.get('stranded', None)
         self.stranded = None

--- a/workflows/chipseq/Snakefile
+++ b/workflows/chipseq/Snakefile
@@ -10,6 +10,7 @@ import pybedtools
 from lib import common, utils, helpers, aligners, chipseq
 from lib.patterns_targets import ChIPSeqConfig
 from lib.utils import autobump, gb, hours
+from pathlib import Path
 
 # ----------------------------------------------------------------------------
 #
@@ -30,7 +31,8 @@ helpers.preflight(config)
 
 c = ChIPSeqConfig(
     config,
-    config.get('patterns', 'config/chipseq_patterns.yaml')
+    config.get('patterns', 'config/chipseq_patterns.yaml'),
+    Path('.').resolve()
 )
 
 SAMPLES = c.sampletable.iloc[:, 0].values

--- a/workflows/rnaseq/Snakefile
+++ b/workflows/rnaseq/Snakefile
@@ -9,6 +9,7 @@ import pandas as pd
 from lib import common, utils, helpers, aligners
 from lib.utils import autobump, gb, hours
 from lib.patterns_targets import RNASeqConfig
+from pathlib import Path
 
 # ----------------------------------------------------------------------------
 #
@@ -27,7 +28,7 @@ include: '../references/Snakefile'
 # Verify configuration of config and sampletable files
 helpers.preflight(config)
 
-c = RNASeqConfig(config, config.get('patterns', 'config/rnaseq_patterns.yaml'))
+c = RNASeqConfig(config, config.get('patterns', 'config/rnaseq_patterns.yaml'), Path('.').resolve())
 
 SAMPLES = c.sampletable.iloc[:, 0].values
 wildcard_constraints:


### PR DESCRIPTION
Make it so that all of the paths in config are absolute paths, which fixes the issue of relative paths breaking when running from a different directory, e.g. when running unit tests from the test/ directory
