### PR TITLE
Cast genome count to string in macs2 wrapper

### DIFF
--- a/wrappers/wrappers/macs2/callpeak/wrapper.py
+++ b/wrappers/wrappers/macs2/callpeak/wrapper.py
@@ -15,7 +15,7 @@ effective_genome_count = snakemake.params.block.get('effective_genome_count',
 
 genome_count_flag = ''
 if effective_genome_count != '':
-    genome_count_flag = ' -g ' + effective_genome_count + ' '
+    genome_count_flag = ' -g ' + str(effective_genome_count) + ' '
 
 cmds = (
     'macs2 '


### PR DESCRIPTION
If the user defines `effective_genome_count` in config.yaml as `2E7`, for example, the value will be read in as a string and there will be no Python concatenation error. However, if the user enters an integer value such as `2056938195` into config.yaml as the `effective_genome_count`, the value will be read in as an integer and Python will error: can't concatenate int with str. 

Even if we remove this wrapper script in future versions of lcdbwf, if this line persists elsewhere, it should be updated to force the effective_genome_count value from config.yaml into str for concatenation. 