### PR TITLE
fix double-negation duplicate bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,6 @@ jobs:
 
   build-docs:
     <<: *defaults
-    resource_class: small
     steps:
       - checkout
       - *restore_cache

--- a/lib/lcdbwf/R/helpers.R
+++ b/lib/lcdbwf/R/helpers.R
@@ -621,7 +621,7 @@ compose_results <- function(res_list=NULL,
   }
 
   # remove duplicates
-  idx <- !duplicated(gene2symbol)
+  idx <- duplicated(gene2symbol)
   gene2symbol <- gene2symbol[!idx]
   names(gene2symbol) <- gene2symbol_names[!idx]
 


### PR DESCRIPTION
This fixes a bug whereby duplicates were incorrectly being kept instead of being removed which resulted in `NA`s for non-duplicated gene names in the `all_rld` object.
- this only affected single-contrast `res_list` objects when they were being converted to 'carnation'-native form 